### PR TITLE
Fix/send by email signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.1] - 2025-07-21
+
+### Fixed
+
+- Fix `Invoices.SendByEmailAsync`, `Receipts.SendByEmailAsync`, `Retentions.SendByEmailAsync` method and mark the `data` parameter as optional.
+
+### Added
+
+- Add `AddOns` property to `Organization` model to support Facturapi add-ons.
+- Add missing properties to `Organization.Customization.PdfExtra` model: `AddressCodes`, `RoundUnitPrice`, `TaxBreakdown`, `IepsBreakdown`, `RenderCartaPorte`, and `RepeatSignature`.
+
 ## [4.9.0] - 2025-06-16
 
 ### Added

--- a/Models/Organization.cs
+++ b/Models/Organization.cs
@@ -14,5 +14,6 @@ namespace Facturapi
         public SelfInvoiceSettings SelfInvoice { get; set; }
         public Certificate Certificate { get; set; }
         public List<LiveApiKey> ApiKeys { get; set; }
+        public List<string> AddOns { get; set; }
     }
 }

--- a/Models/PdfExtra.cs
+++ b/Models/PdfExtra.cs
@@ -3,6 +3,12 @@ namespace Facturapi
     public class PdfExtra
     {
         public bool Codes { get; set; }
+        public bool AddressCodes { get; set; }
         public bool ProductKey { get; set; }
+        public bool RoundUnitPrice { get; set; }
+        public bool TaxBreakdown { get; set; }
+        public bool IepsBreakdown { get; set; }
+        public bool RenderCartaPorte { get; set; }
+        public bool RepeatSignature { get; set; }
     }
 }

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -70,7 +70,7 @@ namespace Facturapi.Wrappers
             return invoice;
         }
 
-        public async Task SendByEmailAsync(string id, Dictionary<string, object> data)
+        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
         {
             var response = await client.PostAsync(Router.SendByEmail(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
             if (!response.IsSuccessStatusCode)

--- a/Wrappers/ReceiptWrapper.cs
+++ b/Wrappers/ReceiptWrapper.cs
@@ -90,7 +90,7 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task SendByEmailAsync(string id, Dictionary<string, object> data)
+        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
         {
             var response = await client.PostAsync(Router.SendReceiptByEmail(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
             if (!response.IsSuccessStatusCode)

--- a/Wrappers/RetentionWrapper.cs
+++ b/Wrappers/RetentionWrapper.cs
@@ -70,7 +70,7 @@ namespace Facturapi.Wrappers
             return customer;
         }
 
-        public async Task SendByEmailAsync(string id, Dictionary<string, object> data)
+        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
         {
             var response = await client.PostAsync(Router.SendRetentionByEmail(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
             if (!response.IsSuccessStatusCode)

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -11,7 +11,7 @@
       API Keys creando una cuenta gratuita en https://www.facturapi.io</Summary>
     <PackageTags>factura factura-electronica cfdi facturapi mexico conekta</PackageTags>
     <Title>Facturapi</Title>
-    <Version>4.9.0</Version>
+    <Version>4.9.1</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Owners>Facturapi</Owners>
     <ApplicationIcon>facturapi.ico</ApplicationIcon>


### PR DESCRIPTION
- Fix signature for `SendByEmail` methods. Make second parameter optional.
- Add missing properties to `Organization.Customization.PdfExtra`.