### PR TITLE
Feat/improve resource cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,41 +10,41 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '8.0.x' # Adjust the .NET version as needed
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x" # Adjust the .NET version as needed
 
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
 
-    - name: Pack
-      run: dotnet pack --configuration Release --no-build --output ./nupkg
+      - name: Pack
+        run: dotnet pack --configuration Release --no-build --output ./nupkg
 
-    - name: Install xmllint
-      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
-    - name: Check if version exists on NuGet
-      id: version-check
-      run: |
-        PACKAGE_ID="Facturapi"
-        VERSION=$(xmllint --xpath "string(//Project/PropertyGroup/Version)" facturapi-net.csproj)
-        echo "Detected version: $VERSION"
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        if curl -sSf "https://api.nuget.org/v3-flatcontainer/${PACKAGE_ID,,}/$VERSION/${PACKAGE_ID,,}.$VERSION.nupkg" > /dev/null; then
-          echo "Version $VERSION already exists. Skipping push."
-          echo "exists=true" >> $GITHUB_OUTPUT
-        else
-          echo "Version $VERSION does not exist. Proceeding with publish."
-          echo "exists=false" >> $GITHUB_OUTPUT
-        fi
+      - name: Check if version exists on NuGet
+        id: version-check
+        run: |
+          PACKAGE_ID="Facturapi"
+          VERSION=$(xmllint --xpath "string(//Project/PropertyGroup/Version)" facturapi-net.csproj)
+          echo "Detected version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if curl -sSf "https://api.nuget.org/v3-flatcontainer/${PACKAGE_ID,,}/$VERSION/${PACKAGE_ID,,}.$VERSION.nupkg" > /dev/null; then
+            echo "Version $VERSION already exists. Skipping push."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION does not exist. Proceeding with publish."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
 
-    - name: Publish to NuGet
-      if: steps.version-check.outputs.exists == 'false'
-      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      - name: Publish to NuGet
+        if: steps.version-check.outputs.exists == 'false'
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - Wrappers can no longer be constructed directly; their constructors are internal and they are intended to be used only through `FacturapiClient`.
+- Renamed existing methods to match documented C# surface: `Organization.List/Create/Update/DeleteSeriesAsync` (were `*SeriesGroupAsync`), `Invoice.UpdateStatusAsync` (was `UpdateStatus`), and `Tools.ValidateTaxIdAsync` (was `ValidateTaxId`).
 
 ### Added
 
 - Expose webhook methods through `FacturapiClient`/`IFacturapiClient`.
-- New organization endpoints: `GetCurrentAsync` (`/organizations/me`), `CheckDomainAvailabilityAsync`, `UpdateReceiptsAsync`, and `UpdateDomainAsync`.
+- New organization endpoints: `MeAsync` (`/organizations/me`), `CheckDomainIsAvailableAsync`, `UpdateReceiptSettingsAsync`, and `UpdateDomainAsync`.
 - Added `DomainAvailability` model for domain check responses.
 - Added `Tool.HealthCheckAsync` for `/check`.
 - `FacturapiException.Status` now surfaces the HTTP status code when available.
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Invoices.PreviewPdfAsync` now calls the documented POST endpoint with a JSON body (breaking change to the method signature).
 - `Receipts.CreateGlobalInvoiceAsync` posts directly to `/receipts/global-invoice` and no longer requires an id (breaking change to the signature).
 - Receipt routes now hit `/receipts/{id}` for cancel, invoice, email, and PDF download instead of invoice endpoints.
-- `Organizations.CreateSeriesGroupAsync` uses POST (not PUT) to `/organizations/{id}/series-group`, matching the API.
+- `Organizations.CreateSeriesAsync` uses POST (not PUT) to `/organizations/{id}/series-group`, matching the API.
 
 ## [4.11.0] - 2025-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - Unreleased
+## [5.0.0] - 2025-12-10
 
 ### Breaking
 
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `FacturapiException.Status` now surfaces the HTTP status code when available.
+- Introduced `IFacturapiClient` so consumers can mock the client surface in tests.
 
 ### Changed
 
-- `FacturapiClient` now implements `IDisposable`; dispose it when finished to release HTTP resources. If not disposed, garbage collection will eventually clean up, but explicit disposal avoids lingering HTTP connections.
+- `FacturapiClient` now implements `IDisposable`; call `Dispose()` when finished (or wrap in `using`) to release HTTP resources. If not disposed, garbage collection will eventually clean up, but explicit disposal avoids lingering HTTP connections.
 
 ## [4.11.0] - 2025-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FacturapiException.Status` now surfaces the HTTP status code when available.
 - Introduced `IFacturapiClient` so consumers can mock the client surface in tests.
+- Optional `CancellationToken` parameters on client methods to allow request cancellation from callers.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - Wrappers can no longer be constructed directly; their constructors are internal and they are intended to be used only through `FacturapiClient`.
-- Renamed existing methods to match documented C# surface: `Organization.List/Create/Update/DeleteSeriesAsync` (were `*SeriesGroupAsync`), `Invoice.UpdateStatusAsync` (was `UpdateStatus`), and `Tools.ValidateTaxIdAsync` (was `ValidateTaxId`).
+- Renamed existing methods to match documented C# surface: `Organization.List/Create/Update/DeleteSeriesAsync` (were `*SeriesGroupAsync`), `Invoice.UpdateStatusAsync` (was `UpdateStatus`), and `Tool.ValidateTaxIdAsync` (was `ValidateTaxId`).
 - Carta Porte catalog methods moved to a dedicated `CartaporteCatalogWrapper`; `CartaporteCatalog` is now of that type, and `CatalogWrapper` retains only product/unit catalogs.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.12.0] = Unreleased
+## [5.0.0] - Unreleased
+
+### Breaking
+
+- Wrappers can no longer be constructed directly; their constructors are internal and they are intended to be used only through `FacturapiClient`.
 
 ### Added
 
 - `FacturapiException.Status` now surfaces the HTTP status code when available.
+
+### Changed
+
+- `FacturapiClient` now implements `IDisposable`; dispose it when finished to release HTTP resources. If not disposed, garbage collection will eventually clean up, but explicit disposal avoids lingering HTTP connections.
 
 ## [4.11.0] - 2025-12-10
 
@@ -65,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type IepsMode for Tax model
 - Type Factor for Tax model
 
-## [4.7.0] = 2025-02-25
+## [4.7.0] - 2025-02-25
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wrappers can no longer be constructed directly; their constructors are internal and they are intended to be used only through `FacturapiClient`.
 - Renamed existing methods to match documented C# surface: `Organization.List/Create/Update/DeleteSeriesAsync` (were `*SeriesGroupAsync`), `Invoice.UpdateStatusAsync` (was `UpdateStatus`), and `Tools.ValidateTaxIdAsync` (was `ValidateTaxId`).
+- Carta Porte catalog methods moved to a dedicated `CartaporteCatalogWrapper`; `CartaporteCatalog` is now of that type, and `CatalogWrapper` retains only product/unit catalogs.
 
 ### Added
 
 - Expose webhook methods through `FacturapiClient`/`IFacturapiClient`.
 - New organization endpoints: `MeAsync` (`/organizations/me`), `CheckDomainIsAvailableAsync`, `UpdateReceiptSettingsAsync`, and `UpdateDomainAsync`.
+- New `CartaporteCatalogWrapper` for Carta Porte catalog searches.
 - Added `DomainAvailability` model for domain check responses.
 - Added `Tool.HealthCheckAsync` for `/check`.
 - `FacturapiException.Status` now surfaces the HTTP status code when available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose webhook methods through `FacturapiClient`/`IFacturapiClient`.
+- New organization endpoints: `GetCurrentAsync` (`/organizations/me`), `CheckDomainAvailabilityAsync`, `UpdateReceiptsAsync`, and `UpdateDomainAsync`.
+- Added `DomainAvailability` model for domain check responses.
+- Added `Tool.HealthCheckAsync` for `/check`.
 - `FacturapiException.Status` now surfaces the HTTP status code when available.
 - Introduced `IFacturapiClient` so consumers can mock the client surface in tests.
 - Optional `CancellationToken` parameters on client methods to allow request cancellation from callers.
@@ -20,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `FacturapiClient` now implements `IDisposable`; call `Dispose()` when finished (or wrap in `using`) to release HTTP resources. If not disposed, garbage collection will eventually clean up, but explicit disposal avoids lingering HTTP connections.
+
+### Fixed
+
+- `Invoices.PreviewPdfAsync` now calls the documented POST endpoint with a JSON body (breaking change to the method signature).
+- `Receipts.CreateGlobalInvoiceAsync` posts directly to `/receipts/global-invoice` and no longer requires an id (breaking change to the signature).
+- Receipt routes now hit `/receipts/{id}` for cancel, invoice, email, and PDF download instead of invoice endpoints.
+- `Organizations.CreateSeriesGroupAsync` uses POST (not PUT) to `/organizations/{id}/series-group`, matching the API.
 
 ## [4.11.0] - 2025-12-10
 

--- a/FacturapiClient.cs
+++ b/FacturapiClient.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Facturapi
 {
-    public class FacturapiClient : IDisposable
+    public class FacturapiClient : IFacturapiClient
     {
         public Wrappers.CustomerWrapper Customer { get; private set; }
         public Wrappers.ProductWrapper Product { get; private set; }

--- a/FacturapiClient.cs
+++ b/FacturapiClient.cs
@@ -15,7 +15,7 @@ namespace Facturapi
         public ReceiptWrapper Receipt { get; private set; }
         public RetentionWrapper Retention { get; private set; }
         public CatalogWrapper Catalog { get; private set; }
-        public CatalogWrapper CartaporteCatalog { get; private set; }
+        public CartaporteCatalogWrapper CartaporteCatalog { get; private set; }
         public ToolWrapper Tool { get; private set; }
         public WebhookWrapper Webhook { get; private set; }
         private readonly HttpClient httpClient;
@@ -36,7 +36,7 @@ namespace Facturapi
             this.Receipt = new ReceiptWrapper(apiKey, apiVersion, this.httpClient);
             this.Retention = new RetentionWrapper(apiKey, apiVersion, this.httpClient);
             this.Catalog = new CatalogWrapper(apiKey, apiVersion, this.httpClient);
-            this.CartaporteCatalog = new CatalogWrapper(apiKey, apiVersion, this.httpClient);
+            this.CartaporteCatalog = new CartaporteCatalogWrapper(apiKey, apiVersion, this.httpClient);
             this.Tool = new ToolWrapper(apiKey, apiVersion, this.httpClient);
             this.Webhook = new WebhookWrapper(apiKey, apiVersion, this.httpClient);
         }

--- a/FacturapiClient.cs
+++ b/FacturapiClient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using Facturapi.Wrappers;
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -7,15 +8,16 @@ namespace Facturapi
 {
     public class FacturapiClient : IFacturapiClient
     {
-        public Wrappers.CustomerWrapper Customer { get; private set; }
-        public Wrappers.ProductWrapper Product { get; private set; }
-        public Wrappers.InvoiceWrapper Invoice { get; private set; }
-        public Wrappers.OrganizationWrapper Organization { get; private set; }
-        public Wrappers.ReceiptWrapper Receipt { get; private set; }
-        public Wrappers.RetentionWrapper Retention { get; private set; }
-        public Wrappers.CatalogWrapper Catalog { get; private set; }
-        public Wrappers.CatalogWrapper CartaporteCatalog { get; private set; }
-        public Wrappers.ToolWrapper Tool { get; private set; }
+        public CustomerWrapper Customer { get; private set; }
+        public ProductWrapper Product { get; private set; }
+        public InvoiceWrapper Invoice { get; private set; }
+        public OrganizationWrapper Organization { get; private set; }
+        public ReceiptWrapper Receipt { get; private set; }
+        public RetentionWrapper Retention { get; private set; }
+        public CatalogWrapper Catalog { get; private set; }
+        public CatalogWrapper CartaporteCatalog { get; private set; }
+        public ToolWrapper Tool { get; private set; }
+        public WebhookWrapper Webhook { get; private set; }
         private readonly HttpClient httpClient;
 
         public FacturapiClient(string apiKey, string apiVersion = "v2")
@@ -27,15 +29,16 @@ namespace Facturapi
             };
             this.httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", apiKeyBase64);
 
-            this.Customer = new Wrappers.CustomerWrapper(apiKey, apiVersion, this.httpClient);
-            this.Product = new Wrappers.ProductWrapper(apiKey, apiVersion, this.httpClient);
-            this.Invoice = new Wrappers.InvoiceWrapper(apiKey, apiVersion, this.httpClient);
-            this.Organization = new Wrappers.OrganizationWrapper(apiKey, apiVersion, this.httpClient);
-            this.Receipt = new Wrappers.ReceiptWrapper(apiKey, apiVersion, this.httpClient);
-            this.Retention = new Wrappers.RetentionWrapper(apiKey, apiVersion, this.httpClient);
-            this.Catalog = new Wrappers.CatalogWrapper(apiKey, apiVersion, this.httpClient);
-            this.CartaporteCatalog = new Wrappers.CatalogWrapper(apiKey, apiVersion, this.httpClient);
-            this.Tool = new Wrappers.ToolWrapper(apiKey, apiVersion, this.httpClient);
+            this.Customer = new CustomerWrapper(apiKey, apiVersion, this.httpClient);
+            this.Product = new ProductWrapper(apiKey, apiVersion, this.httpClient);
+            this.Invoice = new InvoiceWrapper(apiKey, apiVersion, this.httpClient);
+            this.Organization = new OrganizationWrapper(apiKey, apiVersion, this.httpClient);
+            this.Receipt = new ReceiptWrapper(apiKey, apiVersion, this.httpClient);
+            this.Retention = new RetentionWrapper(apiKey, apiVersion, this.httpClient);
+            this.Catalog = new CatalogWrapper(apiKey, apiVersion, this.httpClient);
+            this.CartaporteCatalog = new CatalogWrapper(apiKey, apiVersion, this.httpClient);
+            this.Tool = new ToolWrapper(apiKey, apiVersion, this.httpClient);
+            this.Webhook = new WebhookWrapper(apiKey, apiVersion, this.httpClient);
         }
 
         public void Dispose()

--- a/FacturapiClient.cs
+++ b/FacturapiClient.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Facturapi
 {
-    public class FacturapiClient : IFacturapiClient
+    public sealed class FacturapiClient : IFacturapiClient
     {
         public CustomerWrapper Customer { get; private set; }
         public ProductWrapper Product { get; private set; }
@@ -19,6 +19,7 @@ namespace Facturapi
         public ToolWrapper Tool { get; private set; }
         public WebhookWrapper Webhook { get; private set; }
         private readonly HttpClient httpClient;
+        private bool disposed;
 
         public FacturapiClient(string apiKey, string apiVersion = "v2")
         {
@@ -43,7 +44,14 @@ namespace Facturapi
 
         public void Dispose()
         {
+            if (this.disposed)
+            {
+                return;
+            }
+
             this.httpClient?.Dispose();
+            this.disposed = true;
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/FacturapiClient.cs
+++ b/FacturapiClient.cs
@@ -1,6 +1,11 @@
-﻿namespace Facturapi
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Facturapi
 {
-    public class FacturapiClient
+    public class FacturapiClient : IDisposable
     {
         public Wrappers.CustomerWrapper Customer { get; private set; }
         public Wrappers.ProductWrapper Product { get; private set; }
@@ -11,18 +16,31 @@
         public Wrappers.CatalogWrapper Catalog { get; private set; }
         public Wrappers.CatalogWrapper CartaporteCatalog { get; private set; }
         public Wrappers.ToolWrapper Tool { get; private set; }
+        private readonly HttpClient httpClient;
 
         public FacturapiClient(string apiKey, string apiVersion = "v2")
         {
-            this.Customer = new Wrappers.CustomerWrapper(apiKey, apiVersion);
-            this.Product = new Wrappers.ProductWrapper(apiKey, apiVersion);
-            this.Invoice = new Wrappers.InvoiceWrapper(apiKey, apiVersion);
-            this.Organization = new Wrappers.OrganizationWrapper(apiKey, apiVersion);
-            this.Receipt = new Wrappers.ReceiptWrapper(apiKey, apiVersion);
-            this.Retention = new Wrappers.RetentionWrapper(apiKey, apiVersion);
-            this.Catalog = new Wrappers.CatalogWrapper(apiKey, apiVersion);
-            this.CartaporteCatalog = new Wrappers.CatalogWrapper(apiKey, apiVersion);
-            this.Tool = new Wrappers.ToolWrapper(apiKey, apiVersion);
+            var apiKeyBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey + ":"));
+            this.httpClient = new HttpClient
+            {
+                BaseAddress = new Uri($"https://www.facturapi.io/{apiVersion}/")
+            };
+            this.httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", apiKeyBase64);
+
+            this.Customer = new Wrappers.CustomerWrapper(apiKey, apiVersion, this.httpClient);
+            this.Product = new Wrappers.ProductWrapper(apiKey, apiVersion, this.httpClient);
+            this.Invoice = new Wrappers.InvoiceWrapper(apiKey, apiVersion, this.httpClient);
+            this.Organization = new Wrappers.OrganizationWrapper(apiKey, apiVersion, this.httpClient);
+            this.Receipt = new Wrappers.ReceiptWrapper(apiKey, apiVersion, this.httpClient);
+            this.Retention = new Wrappers.RetentionWrapper(apiKey, apiVersion, this.httpClient);
+            this.Catalog = new Wrappers.CatalogWrapper(apiKey, apiVersion, this.httpClient);
+            this.CartaporteCatalog = new Wrappers.CatalogWrapper(apiKey, apiVersion, this.httpClient);
+            this.Tool = new Wrappers.ToolWrapper(apiKey, apiVersion, this.httpClient);
+        }
+
+        public void Dispose()
+        {
+            this.httpClient?.Dispose();
         }
     }
 }

--- a/IFacturapiClient.cs
+++ b/IFacturapiClient.cs
@@ -12,7 +12,7 @@ namespace Facturapi
         ReceiptWrapper Receipt { get; }
         RetentionWrapper Retention { get; }
         CatalogWrapper Catalog { get; }
-        CatalogWrapper CartaporteCatalog { get; }
+        CartaporteCatalogWrapper CartaporteCatalog { get; }
         ToolWrapper Tool { get; }
         WebhookWrapper Webhook { get; }
     }

--- a/IFacturapiClient.cs
+++ b/IFacturapiClient.cs
@@ -14,5 +14,6 @@ namespace Facturapi
         CatalogWrapper Catalog { get; }
         CatalogWrapper CartaporteCatalog { get; }
         ToolWrapper Tool { get; }
+        WebhookWrapper Webhook { get; }
     }
 }

--- a/IFacturapiClient.cs
+++ b/IFacturapiClient.cs
@@ -1,0 +1,18 @@
+﻿using Facturapi.Wrappers;
+using System;
+
+namespace Facturapi
+{
+    public interface IFacturapiClient : IDisposable
+    {
+        CustomerWrapper Customer { get; }
+        ProductWrapper Product { get; }
+        InvoiceWrapper Invoice { get; }
+        OrganizationWrapper Organization { get; }
+        ReceiptWrapper Receipt { get; }
+        RetentionWrapper Retention { get; }
+        CatalogWrapper Catalog { get; }
+        CatalogWrapper CartaporteCatalog { get; }
+        ToolWrapper Tool { get; }
+    }
+}

--- a/Models/DomainAvailability.cs
+++ b/Models/DomainAvailability.cs
@@ -1,0 +1,7 @@
+namespace Facturapi
+{
+    public class DomainAvailability
+    {
+        public bool Available { get; set; }
+    }
+}

--- a/Router/HealthRouter.cs
+++ b/Router/HealthRouter.cs
@@ -1,0 +1,10 @@
+namespace Facturapi
+{
+    internal static partial class Router
+    {
+        public static string HealthCheck()
+        {
+            return "check";
+        }
+    }
+}

--- a/Router/InvoiceRouter.cs
+++ b/Router/InvoiceRouter.cs
@@ -63,9 +63,9 @@ namespace Facturapi
             return $"invoices/{id}/copy";
         }
 
-        public static string PreviewPdf(Dictionary<string, object> query = null)
+        public static string PreviewPdf()
         {
-            return UriWithQuery("invoices/preview/pdf", query);
+            return "invoices/preview/pdf";
         }
     }
 }

--- a/Router/OrganizationRouter.cs
+++ b/Router/OrganizationRouter.cs
@@ -10,6 +10,11 @@ namespace Facturapi
             return UriWithQuery("organizations", query);
         }
 
+        public static string OrganizationMe()
+        {
+            return "organizations/me";
+        }
+
         public static string RetrieveOrganization(string id)
         {
             return $"organizations/{id}";
@@ -23,6 +28,11 @@ namespace Facturapi
         public static string DeleteOrganization(string id)
         {
             return RetrieveOrganization(id);
+        }
+
+        public static string CheckDomainAvailability(Dictionary<string, object> query = null)
+        {
+            return UriWithQuery("organizations/domain-check", query);
         }
 
         public static string UpdateLegal(string id)
@@ -40,6 +50,11 @@ namespace Facturapi
             return $"{RetrieveOrganization(id)}/logo";
         }
         
+        public static string UpdateReceipts(string id)
+        {
+            return $"{RetrieveOrganization(id)}/receipts";
+        }
+
         public static string UploadCertificate(string id)
         {
             return $"{RetrieveOrganization(id)}/certificate";
@@ -99,6 +114,11 @@ namespace Facturapi
         public static string UpdateSelfInvoiceSettings(string organizationId)
         {
             return $"{RetrieveOrganization(organizationId)}/self-invoice";
+        }
+
+        public static string UpdateDomain(string organizationId)
+        {
+            return $"{RetrieveOrganization(organizationId)}/domain";
         }
     }
 }

--- a/Router/ReceiptRouter.cs
+++ b/Router/ReceiptRouter.cs
@@ -30,22 +30,22 @@ namespace Facturapi
 
         public static string InvoiceReceipt(string id)
         {
-            return $"receipts/(id)/invoice";
+            return $"receipts/{id}/invoice";
         }
         
-        public static string CreateGlobalInvoice(string id)
+        public static string CreateGlobalInvoice()
         {
             return $"receipts/global-invoice";
         }
 
         public static string DownloadReceiptPdf(string id)
         {
-            return $"receipts/(id)/pdf";
+            return $"receipts/{id}/pdf";
         }
 
         public static string SendReceiptByEmail(string id)
         {
-            return $"receipts/(id)/email";
+            return $"receipts/{id}/email";
         }
     }
 }

--- a/Wrappers/BaseWrapper.cs
+++ b/Wrappers/BaseWrapper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -69,8 +70,10 @@ namespace Facturapi.Wrappers
             return new FacturapiException(message, status);
         }
 
-        protected async Task ThrowIfErrorAsync(HttpResponseMessage response)
+        protected async Task ThrowIfErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (response.IsSuccessStatusCode)
             {
                 return;

--- a/Wrappers/BaseWrapper.cs
+++ b/Wrappers/BaseWrapper.cs
@@ -9,20 +9,17 @@ namespace Facturapi.Wrappers
 {
     public abstract class BaseWrapper
     {
-        protected const string BASE_URL = "https://www.facturapi.io/";
         protected HttpClient client;
         protected JsonSerializerSettings jsonSettings { get; set; }
         public string apiKey { get; set; }
         public string apiVersion {  get; set; }
 
-        public BaseWrapper(string apiKey, string apiVersion = "v2")
+        public BaseWrapper(string apiKey, string apiVersion, HttpClient httpClient)
         {
-            var apiKeyBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey + ":"));
-            this.client = new HttpClient()
-            {
-                BaseAddress = new Uri($"{BASE_URL}/{apiVersion}/")
-            };
-            this.client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", apiKeyBase64);
+            this.apiKey = apiKey;
+            this.apiVersion = apiVersion;
+
+            this.client = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             this.jsonSettings = new JsonSerializerSettings
             {
                 ContractResolver = new SnakeCasePropertyNamesContractResolver(),

--- a/Wrappers/CartaporteCatalogWrapper.cs
+++ b/Wrappers/CartaporteCatalogWrapper.cs
@@ -1,0 +1,76 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Facturapi.Wrappers
+{
+    public class CartaporteCatalogWrapper : BaseWrapper
+    {
+        internal CartaporteCatalogWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
+        {
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchAirTransportCodes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteAirTransportCodes(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchTransportConfigs(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteTransportConfigs(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchRightsOfPassage(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteRightsOfPassage(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchCustomsDocuments(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteCustomsDocuments(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchPackagingTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaportePackagingTypes(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchTrailerTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteTrailerTypes(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchHazardousMaterials(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteHazardousMaterials(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchNavalAuthorizations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteNavalAuthorizations(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchPortStations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaportePortStations(query), cancellationToken);
+        }
+
+        public async Task<SearchResult<CatalogItem>> SearchMarineContainers(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        {
+            return await this.SearchCatalogAsync(Router.SearchCartaporteMarineContainers(query), cancellationToken);
+        }
+
+        private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url, CancellationToken cancellationToken)
+        {
+            using (var response = await client.GetAsync(url, cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<CatalogItem>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
+        }
+    }
+}

--- a/Wrappers/CatalogWrapper.cs
+++ b/Wrappers/CatalogWrapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -11,72 +12,72 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchProducts(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchProducts(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchProductKeys(query));
+            return await this.SearchCatalogAsync(Router.SearchProductKeys(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchUnits(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchUnits(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchUnitKeys(query));
+            return await this.SearchCatalogAsync(Router.SearchUnitKeys(query), cancellationToken);
         }
 
         // Carta Porte catalogs
-        public async Task<SearchResult<CatalogItem>> SearchAirTransportCodes(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchAirTransportCodes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteAirTransportCodes(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteAirTransportCodes(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchTransportConfigs(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchTransportConfigs(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteTransportConfigs(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteTransportConfigs(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchRightsOfPassage(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchRightsOfPassage(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteRightsOfPassage(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteRightsOfPassage(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchCustomsDocuments(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchCustomsDocuments(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteCustomsDocuments(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteCustomsDocuments(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchPackagingTypes(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchPackagingTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaportePackagingTypes(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaportePackagingTypes(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchTrailerTypes(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchTrailerTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteTrailerTypes(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteTrailerTypes(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchHazardousMaterials(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchHazardousMaterials(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteHazardousMaterials(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteHazardousMaterials(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchNavalAuthorizations(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchNavalAuthorizations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteNavalAuthorizations(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteNavalAuthorizations(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchPortStations(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchPortStations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaportePortStations(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaportePortStations(query), cancellationToken);
         }
 
-        public async Task<SearchResult<CatalogItem>> SearchMarineContainers(Dictionary<string, object> query = null)
+        public async Task<SearchResult<CatalogItem>> SearchMarineContainers(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteMarineContainers(query));
+            return await this.SearchCatalogAsync(Router.SearchCartaporteMarineContainers(query), cancellationToken);
         }
 
-        private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url)
+        private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(url))
+            using (var response = await client.GetAsync(url, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<CatalogItem>>(resultString, this.jsonSettings);
                 return searchResult;

--- a/Wrappers/CatalogWrapper.cs
+++ b/Wrappers/CatalogWrapper.cs
@@ -7,7 +7,7 @@ namespace Facturapi.Wrappers
 {
     public class CatalogWrapper : BaseWrapper
     {
-        public CatalogWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal CatalogWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 

--- a/Wrappers/CatalogWrapper.cs
+++ b/Wrappers/CatalogWrapper.cs
@@ -22,57 +22,6 @@ namespace Facturapi.Wrappers
             return await this.SearchCatalogAsync(Router.SearchUnitKeys(query), cancellationToken);
         }
 
-        // Carta Porte catalogs
-        public async Task<SearchResult<CatalogItem>> SearchAirTransportCodes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteAirTransportCodes(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchTransportConfigs(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteTransportConfigs(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchRightsOfPassage(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteRightsOfPassage(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchCustomsDocuments(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteCustomsDocuments(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchPackagingTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaportePackagingTypes(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchTrailerTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteTrailerTypes(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchHazardousMaterials(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteHazardousMaterials(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchNavalAuthorizations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteNavalAuthorizations(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchPortStations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaportePortStations(query), cancellationToken);
-        }
-
-        public async Task<SearchResult<CatalogItem>> SearchMarineContainers(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
-        {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteMarineContainers(query), cancellationToken);
-        }
-
         private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url, CancellationToken cancellationToken)
         {
             using (var response = await client.GetAsync(url, cancellationToken))

--- a/Wrappers/CustomerWrapper.cs
+++ b/Wrappers/CustomerWrapper.cs
@@ -8,69 +8,86 @@ namespace Facturapi.Wrappers
 {
     public class CustomerWrapper : BaseWrapper
     {
-        public CustomerWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal CustomerWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<SearchResult<Customer>> ListAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.ListCustomers(query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListCustomers(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<SearchResult<Customer>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<Customer>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<Customer> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> queryParams = null)
         {
-            var response = await client.PostAsync(Router.CreateCustomer(queryParams), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
-            return customer;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateCustomer(queryParams), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Customer> RetrieveAsync(string id)
         {
-            var response = await client.GetAsync(Router.RetrieveCustomer(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
-            return customer;
+            using (var response = await client.GetAsync(Router.RetrieveCustomer(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Customer> DeleteAsync(string id)
         {
-            var response = await client.DeleteAsync(Router.DeleteCustomer(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
-            return customer;
+            using (var response = await client.DeleteAsync(Router.DeleteCustomer(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Customer> UpdateAsync(string id, Dictionary<string, object> data, Dictionary<string, object> queryParams = null)
         {
-            var response = await client.PutAsync(Router.UpdateCustomer(id, queryParams), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
-            return customer;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateCustomer(id, queryParams), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<TaxInfoValidation> ValidateTaxInfoAsync(string id)
         {
-            var response = await client.GetAsync(Router.ValidateCustomerTaxInfo(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var validation = JsonConvert.DeserializeObject<TaxInfoValidation>(resultString, this.jsonSettings);
-            return validation;
+            using (var response = await client.GetAsync(Router.ValidateCustomerTaxInfo(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var validation = JsonConvert.DeserializeObject<TaxInfoValidation>(resultString, this.jsonSettings);
+                return validation;
+            }
         }
 
         public async Task SendEditLinkByEmailAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.SendEditLinkByEmail(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.SendEditLinkByEmail(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+            }
         }
     }
 }

--- a/Wrappers/CustomerWrapper.cs
+++ b/Wrappers/CustomerWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -12,11 +13,11 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<Customer>> ListAsync(Dictionary<string, object> query = null)
+        public async Task<SearchResult<Customer>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListCustomers(query)))
+            using (var response = await client.GetAsync(Router.ListCustomers(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Customer>>(resultString, this.jsonSettings);
@@ -24,69 +25,69 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Customer> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> queryParams = null)
+        public async Task<Customer> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> queryParams = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateCustomer(queryParams), content))
+            using (var response = await client.PostAsync(Router.CreateCustomer(queryParams), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Customer> RetrieveAsync(string id)
+        public async Task<Customer> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveCustomer(id)))
+            using (var response = await client.GetAsync(Router.RetrieveCustomer(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Customer> DeleteAsync(string id)
+        public async Task<Customer> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteCustomer(id)))
+            using (var response = await client.DeleteAsync(Router.DeleteCustomer(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Customer> UpdateAsync(string id, Dictionary<string, object> data, Dictionary<string, object> queryParams = null)
+        public async Task<Customer> UpdateAsync(string id, Dictionary<string, object> data, Dictionary<string, object> queryParams = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateCustomer(id, queryParams), content))
+            using (var response = await client.PutAsync(Router.UpdateCustomer(id, queryParams), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<TaxInfoValidation> ValidateTaxInfoAsync(string id)
+        public async Task<TaxInfoValidation> ValidateTaxInfoAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ValidateCustomerTaxInfo(id)))
+            using (var response = await client.GetAsync(Router.ValidateCustomerTaxInfo(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var validation = JsonConvert.DeserializeObject<TaxInfoValidation>(resultString, this.jsonSettings);
                 return validation;
             }
         }
 
-        public async Task SendEditLinkByEmailAsync(string id, Dictionary<string, object> data)
+        public async Task SendEditLinkByEmailAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendEditLinkByEmail(id), content))
+            using (var response = await client.PostAsync(Router.SendEditLinkByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
             }
         }
     }

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -120,7 +120,7 @@ namespace Facturapi.Wrappers
             return DownloadCancellationReceiptAsync(id, "pdf", cancellationToken);
         }
 
-        public async Task<Invoice> UpdateStatus(string id, CancellationToken cancellationToken = default)
+        public async Task<Invoice> UpdateStatusAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateStatus(id), content, cancellationToken))

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -9,59 +9,76 @@ namespace Facturapi.Wrappers
 {
     public class InvoiceWrapper : BaseWrapper
     {
-        public InvoiceWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal InvoiceWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.ListInvoices(query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListInvoices(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<Invoice> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> options = null)
         {
-            var response = await client.PostAsync(Router.CreateInvoice(options), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return invoice;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateInvoice(options), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return invoice;
+            }
         }
 
         public async Task<Invoice> RetrieveAsync(string id)
         {
-            var response = await client.GetAsync(Router.RetrieveInvoice(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return invoice;
+            using (var response = await client.GetAsync(Router.RetrieveInvoice(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return invoice;
+            }
         }
 
         public async Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null)
         {
-            var response = await client.DeleteAsync(Router.CancelInvoice(id, query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return invoice;
+            using (var response = await client.DeleteAsync(Router.CancelInvoice(id, query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return invoice;
+            }
         }
 
         public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
         {
-            var response = await client.PostAsync(Router.SendByEmail(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.SendByEmail(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+            }
         }
 
         private async Task<Stream> DownloadAsync(string id, string format)
         {
-            var response = await client.GetAsync(Router.DownloadInvoice(id, format));
-            await this.ThrowIfErrorAsync(response);
-            var stream = await response.Content.ReadAsStreamAsync();
-            return stream;
+            using (var response = await client.GetAsync(Router.DownloadInvoice(id, format)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var responseStream = await response.Content.ReadAsStreamAsync();
+                var memory = new MemoryStream();
+                await responseStream.CopyToAsync(memory);
+                memory.Position = 0;
+                return memory;
+            }
         }
 
         public Task<Stream> DownloadZipAsync(string id)
@@ -81,10 +98,15 @@ namespace Facturapi.Wrappers
 
         private async Task<Stream> DownloadCancellationReceiptAsync(string id, string format)
         {
-            var response = await client.GetAsync(Router.DownloadCancellationReceipt(id, format));
-            await this.ThrowIfErrorAsync(response);
-            var stream = await response.Content.ReadAsStreamAsync();
-            return stream;
+            using (var response = await client.GetAsync(Router.DownloadCancellationReceipt(id, format)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var responseStream = await response.Content.ReadAsStreamAsync();
+                var memory = new MemoryStream();
+                await responseStream.CopyToAsync(memory);
+                memory.Position = 0;
+                return memory;
+            }
         }
 
         public Task<Stream> DownloadCancellationReceiptXmlAsync(string id)
@@ -99,46 +121,63 @@ namespace Facturapi.Wrappers
 
         public async Task<Invoice> UpdateStatus(string id)
         {
-            var response = await client.PutAsync(Router.UpdateStatus(id), new StringContent("", Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return invoice;
+            using (var content = new StringContent("", Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateStatus(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return invoice;
+            }
         }
 
         public async Task<Invoice> UpdateDraftAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PutAsync(Router.UpdateDraftInvoice(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return invoice;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateDraftInvoice(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return invoice;
+            }
         }
 
         public async Task<Invoice> StampDraft(string id, Dictionary<string, object> options = null)
         {
-            var response = await client.PostAsync(Router.StampDraftInvoice(id, options), new StringContent("", Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return invoice;
+            using (var content = new StringContent("", Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.StampDraftInvoice(id, options), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return invoice;
+            }
         }
 
         public async Task<Invoice> CopyToDraftAsync(string id)
         {
-            var response = await client.PostAsync(Router.CopyInvoice(id), new StringContent("", Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return invoice;
+            using (var content = new StringContent("", Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CopyInvoice(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return invoice;
+            }
         }
 
         public async Task<Stream> PreviewPdfAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.PreviewPdf(query));
-            await this.ThrowIfErrorAsync(response);
-            var stream = await response.Content.ReadAsStreamAsync();
-            return stream;
+            using (var response = await client.GetAsync(Router.PreviewPdf(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var responseStream = await response.Content.ReadAsStreamAsync();
+                var memory = new MemoryStream();
+                await responseStream.CopyToAsync(memory);
+                memory.Position = 0;
+                return memory;
+            }
         }
     }
 }

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -168,9 +168,10 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Stream> PreviewPdfAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
+        public async Task<Stream> PreviewPdfAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.PreviewPdf(query), cancellationToken))
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.PreviewPdf(), content, cancellationToken))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken);
                 var responseStream = await response.Content.ReadAsStreamAsync();

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -13,11 +14,11 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null)
+        public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListInvoices(query)))
+            using (var response = await client.GetAsync(Router.ListInvoices(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
@@ -25,156 +26,156 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Invoice> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> options = null)
+        public async Task<Invoice> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> options = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateInvoice(options), content))
+            using (var response = await client.PostAsync(Router.CreateInvoice(options), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task<Invoice> RetrieveAsync(string id)
+        public async Task<Invoice> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveInvoice(id)))
+            using (var response = await client.GetAsync(Router.RetrieveInvoice(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null)
+        public async Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.CancelInvoice(id, query)))
+            using (var response = await client.DeleteAsync(Router.CancelInvoice(id, query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
+        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendByEmail(id), content))
+            using (var response = await client.PostAsync(Router.SendByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
             }
         }
 
-        private async Task<Stream> DownloadAsync(string id, string format)
+        private async Task<Stream> DownloadAsync(string id, string format, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(Router.DownloadInvoice(id, format)))
+            using (var response = await client.GetAsync(Router.DownloadInvoice(id, format), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var responseStream = await response.Content.ReadAsStreamAsync();
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
                 memory.Position = 0;
                 return memory;
             }
         }
 
-        public Task<Stream> DownloadZipAsync(string id)
+        public Task<Stream> DownloadZipAsync(string id, CancellationToken cancellationToken = default)
         {
-            return this.DownloadAsync(id, "zip");
+            return this.DownloadAsync(id, "zip", cancellationToken);
         }
 
-        public Task<Stream> DownloadPdfAsync(string id)
+        public Task<Stream> DownloadPdfAsync(string id, CancellationToken cancellationToken = default)
         {
-            return this.DownloadAsync(id, "pdf");
+            return this.DownloadAsync(id, "pdf", cancellationToken);
         }
 
-        public Task<Stream> DownloadXmlAsync(string id)
+        public Task<Stream> DownloadXmlAsync(string id, CancellationToken cancellationToken = default)
         {
-            return this.DownloadAsync(id, "xml");
+            return this.DownloadAsync(id, "xml", cancellationToken);
         }
 
-        private async Task<Stream> DownloadCancellationReceiptAsync(string id, string format)
+        private async Task<Stream> DownloadCancellationReceiptAsync(string id, string format, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(Router.DownloadCancellationReceipt(id, format)))
+            using (var response = await client.GetAsync(Router.DownloadCancellationReceipt(id, format), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var responseStream = await response.Content.ReadAsStreamAsync();
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
                 memory.Position = 0;
                 return memory;
             }
         }
 
-        public Task<Stream> DownloadCancellationReceiptXmlAsync(string id)
+        public Task<Stream> DownloadCancellationReceiptXmlAsync(string id, CancellationToken cancellationToken = default)
         {
-            return DownloadCancellationReceiptAsync(id, "xml");
+            return DownloadCancellationReceiptAsync(id, "xml", cancellationToken);
         }
 
-        public Task<Stream> DownloadCancellationReceiptPdfAsync(string id)
+        public Task<Stream> DownloadCancellationReceiptPdfAsync(string id, CancellationToken cancellationToken = default)
         {
-            return DownloadCancellationReceiptAsync(id, "pdf");
+            return DownloadCancellationReceiptAsync(id, "pdf", cancellationToken);
         }
 
-        public async Task<Invoice> UpdateStatus(string id)
+        public async Task<Invoice> UpdateStatus(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateStatus(id), content))
+            using (var response = await client.PutAsync(Router.UpdateStatus(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task<Invoice> UpdateDraftAsync(string id, Dictionary<string, object> data)
+        public async Task<Invoice> UpdateDraftAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateDraftInvoice(id), content))
+            using (var response = await client.PutAsync(Router.UpdateDraftInvoice(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task<Invoice> StampDraft(string id, Dictionary<string, object> options = null)
+        public async Task<Invoice> StampDraft(string id, Dictionary<string, object> options = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.StampDraftInvoice(id, options), content))
+            using (var response = await client.PostAsync(Router.StampDraftInvoice(id, options), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task<Invoice> CopyToDraftAsync(string id)
+        public async Task<Invoice> CopyToDraftAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CopyInvoice(id), content))
+            using (var response = await client.PostAsync(Router.CopyInvoice(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task<Stream> PreviewPdfAsync(Dictionary<string, object> query = null)
+        public async Task<Stream> PreviewPdfAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.PreviewPdf(query)))
+            using (var response = await client.GetAsync(Router.PreviewPdf(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var responseStream = await response.Content.ReadAsStreamAsync();
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
                 memory.Position = 0;
                 return memory;
             }

--- a/Wrappers/OrganizationWrapper.cs
+++ b/Wrappers/OrganizationWrapper.cs
@@ -26,6 +26,28 @@ namespace Facturapi.Wrappers
             }
         }
 
+        public async Task<Organization> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.OrganizationMe(), cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
+        }
+
+        public async Task<DomainAvailability> CheckDomainAvailabilityAsync(string domain, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.CheckDomainAvailability(new Dictionary<string, object> { ["domain"] = domain }), cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var availability = JsonConvert.DeserializeObject<DomainAvailability>(resultString, this.jsonSettings);
+                return availability;
+            }
+        }
+
         public async Task<Organization> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
@@ -115,10 +137,34 @@ namespace Facturapi.Wrappers
             }
         }
 
+        public async Task<Organization> UpdateReceiptsAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateReceipts(id), content, cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
+        }
+
         public async Task<Organization> UpdateCustomizationAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateCustomization(id), content, cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
+        }
+
+        public async Task<Organization> UpdateDomainAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateDomain(id), content, cancellationToken))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
@@ -188,7 +234,7 @@ namespace Facturapi.Wrappers
         public async Task<SeriesGroup> CreateSeriesGroupAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.CreateSeriesGroup(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateSeriesGroup(id), content, cancellationToken))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();

--- a/Wrappers/OrganizationWrapper.cs
+++ b/Wrappers/OrganizationWrapper.cs
@@ -9,187 +9,237 @@ namespace Facturapi.Wrappers
 {
     public class OrganizationWrapper : BaseWrapper
     {
-        public OrganizationWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal OrganizationWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<SearchResult<Organization>> ListAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.ListOrganizations(query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListOrganizations(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<SearchResult<Organization>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<Organization>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<Organization> CreateAsync(Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.CreateOrganization(), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateOrganization(), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
         }
 
         public async Task<Organization> RetrieveAsync(string id)
         {
-            var response = await client.GetAsync(Router.RetrieveOrganization(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var response = await client.GetAsync(Router.RetrieveOrganization(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
         }
 
         public async Task<Organization> DeleteAsync(string id)
         {
-            var response = await client.DeleteAsync(Router.DeleteOrganization(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var response = await client.DeleteAsync(Router.DeleteOrganization(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
         }
 
         public async Task<Organization> UploadLogoAsync(string id, Stream file)
         {
-            var form = new MultipartFormDataContent();
-            form.Add(new StreamContent(file), "file", "logo.jpg");
-            var response = await client.PutAsync(Router.UploadLogo(id), form);
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var form = new MultipartFormDataContent())
+            {
+                form.Add(new StreamContent(file), "file", "logo.jpg");
+                using (var response = await client.PutAsync(Router.UploadLogo(id), form))
+                {
+                    await this.ThrowIfErrorAsync(response);
+                    var resultString = await response.Content.ReadAsStringAsync();
+                    var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                    return organization;
+                }
+            }
         }
 
         public async Task<Organization> UploadCertificateAsync(string id, Stream cerFile, Stream keyFile, string password)
         {
-            var form = new MultipartFormDataContent();
-            form.Add(new StreamContent(cerFile), "cer", "certificate.cer");
-            form.Add(new StreamContent(keyFile), "key", "key.key");
-            form.Add(new StringContent(password), "password");
-            var response = await client.PutAsync(Router.UploadCertificate(id), form);
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var form = new MultipartFormDataContent())
+            {
+                form.Add(new StreamContent(cerFile), "cer", "certificate.cer");
+                form.Add(new StreamContent(keyFile), "key", "key.key");
+                form.Add(new StringContent(password), "password");
+                using (var response = await client.PutAsync(Router.UploadCertificate(id), form))
+                {
+                    await this.ThrowIfErrorAsync(response);
+                    var resultString = await response.Content.ReadAsStringAsync();
+                    var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                    return organization;
+                }
+            }
         }
 
         public async Task<Certificate> DeleteCertificateAsync(string id)
         {
-            var response = await client.DeleteAsync(Router.DeleteCertificate(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var certificateInfo = JsonConvert.DeserializeObject<Certificate>(resultString, this.jsonSettings);
-            return certificateInfo;
+            using (var response = await client.DeleteAsync(Router.DeleteCertificate(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var certificateInfo = JsonConvert.DeserializeObject<Certificate>(resultString, this.jsonSettings);
+                return certificateInfo;
+            }
         }
 
         public async Task<Organization> UpdateLegalAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PutAsync(Router.UpdateLegal(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateLegal(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
         }
 
         public async Task<Organization> UpdateCustomizationAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PutAsync(Router.UpdateCustomization(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateCustomization(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
         }
 
         public async Task<string> GetTestApiKeyAsync(string id)
         {
-            var response = await client.GetAsync(Router.GetTestApiKey(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            return resultString;
+            using (var response = await client.GetAsync(Router.GetTestApiKey(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                return resultString;
+            }
         }
 
 
         public async Task<string> RenewTestApiKeyAsync(string id)
         {
-            var response = await client.PutAsync(Router.RenewTestApiKey(id), new StringContent(""));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            return resultString;
+            using (var content = new StringContent(""))
+            using (var response = await client.PutAsync(Router.RenewTestApiKey(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                return resultString;
+            }
         }
 
         public async Task<LiveApiKey> ListLiveApiKeysAsync(string id)
         {
-            var response = await client.GetAsync(Router.ListAsyncLiveApiKeys(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var listResult = JsonConvert.DeserializeObject<LiveApiKey>(resultString, this.jsonSettings);
+            using (var response = await client.GetAsync(Router.ListAsyncLiveApiKeys(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var listResult = JsonConvert.DeserializeObject<LiveApiKey>(resultString, this.jsonSettings);
 
-            return listResult;
+                return listResult;
+            }
         }
 
         public async Task<string> RenewLiveApiKeyAsync(string id)
         {
-            var response = await client.PutAsync(Router.RenewLiveApiKey(id), new StringContent(""));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            return resultString;
+            using (var content = new StringContent(""))
+            using (var response = await client.PutAsync(Router.RenewLiveApiKey(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                return resultString;
+            }
         }
 
 
         public async Task<List<SeriesGroup>> ListSeriesGroupAsync(string id)
         {
-            var response = await client.GetAsync(Router.ListSeriesGroup(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListSeriesGroup(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<List<SeriesGroup>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<List<SeriesGroup>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<SeriesGroup> CreateSeriesGroupAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PutAsync(Router.CreateSeriesGroup(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
-            return series;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.CreateSeriesGroup(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
+                return series;
+            }
         }
 
         public async Task<SeriesGroup> UpdateSeriesGroupAsync(string id, string seriesName, Dictionary<string, object> data)
         {
-            var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
-            return series;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
+                return series;
+            }
         }
         
         public async Task<SeriesGroup> DeleteSeriesGroupAsync(string id, string seriesName)
         {
-            var response = await client.DeleteAsync(Router.UpdateSeriesGroup(id, seriesName));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
-            return series;
+            using (var response = await client.DeleteAsync(Router.UpdateSeriesGroup(id, seriesName)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
+                return series;
+            }
         }
         
         public async Task<List<LiveApiKey>> DeleteLiveApiKeyAsync(string id, string apiKeyId)
         {
-            var response = await client.DeleteAsync(Router.DeleteLiveApiKey(id, apiKeyId));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var deserializeJson = JsonConvert.DeserializeObject<List<LiveApiKey>>(resultString, this.jsonSettings);
-            return deserializeJson;
+            using (var response = await client.DeleteAsync(Router.DeleteLiveApiKey(id, apiKeyId)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var deserializeJson = JsonConvert.DeserializeObject<List<LiveApiKey>>(resultString, this.jsonSettings);
+                return deserializeJson;
+            }
         }
 
         public async Task<Organization> UpdateSelfInvoiceSettingsAsync(string organizationId, Dictionary<string, object> data)
         {
-            var response = await client.PutAsync(Router.UpdateSelfInvoiceSettings(organizationId), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
-            return organization;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateSelfInvoiceSettings(organizationId), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
+                return organization;
+            }
         }
     }
 }

--- a/Wrappers/OrganizationWrapper.cs
+++ b/Wrappers/OrganizationWrapper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -13,11 +14,11 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<Organization>> ListAsync(Dictionary<string, object> query = null)
+        public async Task<SearchResult<Organization>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListOrganizations(query)))
+            using (var response = await client.GetAsync(Router.ListOrganizations(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Organization>>(resultString, this.jsonSettings);
@@ -25,48 +26,48 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Organization> CreateAsync(Dictionary<string, object> data)
+        public async Task<Organization> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateOrganization(), content))
+            using (var response = await client.PostAsync(Router.CreateOrganization(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
         }
 
-        public async Task<Organization> RetrieveAsync(string id)
+        public async Task<Organization> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveOrganization(id)))
+            using (var response = await client.GetAsync(Router.RetrieveOrganization(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
         }
 
-        public async Task<Organization> DeleteAsync(string id)
+        public async Task<Organization> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteOrganization(id)))
+            using (var response = await client.DeleteAsync(Router.DeleteOrganization(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
         }
 
-        public async Task<Organization> UploadLogoAsync(string id, Stream file)
+        public async Task<Organization> UploadLogoAsync(string id, Stream file, CancellationToken cancellationToken = default)
         {
             using (var form = new MultipartFormDataContent())
             {
                 form.Add(new StreamContent(file), "file", "logo.jpg");
-                using (var response = await client.PutAsync(Router.UploadLogo(id), form))
+                using (var response = await client.PutAsync(Router.UploadLogo(id), form, cancellationToken))
                 {
-                    await this.ThrowIfErrorAsync(response);
+                    await this.ThrowIfErrorAsync(response, cancellationToken);
                     var resultString = await response.Content.ReadAsStringAsync();
                     var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                     return organization;
@@ -74,16 +75,16 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Organization> UploadCertificateAsync(string id, Stream cerFile, Stream keyFile, string password)
+        public async Task<Organization> UploadCertificateAsync(string id, Stream cerFile, Stream keyFile, string password, CancellationToken cancellationToken = default)
         {
             using (var form = new MultipartFormDataContent())
             {
                 form.Add(new StreamContent(cerFile), "cer", "certificate.cer");
                 form.Add(new StreamContent(keyFile), "key", "key.key");
                 form.Add(new StringContent(password), "password");
-                using (var response = await client.PutAsync(Router.UploadCertificate(id), form))
+                using (var response = await client.PutAsync(Router.UploadCertificate(id), form, cancellationToken))
                 {
-                    await this.ThrowIfErrorAsync(response);
+                    await this.ThrowIfErrorAsync(response, cancellationToken);
                     var resultString = await response.Content.ReadAsStringAsync();
                     var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                     return organization;
@@ -91,68 +92,68 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Certificate> DeleteCertificateAsync(string id)
+        public async Task<Certificate> DeleteCertificateAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteCertificate(id)))
+            using (var response = await client.DeleteAsync(Router.DeleteCertificate(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var certificateInfo = JsonConvert.DeserializeObject<Certificate>(resultString, this.jsonSettings);
                 return certificateInfo;
             }
         }
 
-        public async Task<Organization> UpdateLegalAsync(string id, Dictionary<string, object> data)
+        public async Task<Organization> UpdateLegalAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateLegal(id), content))
+            using (var response = await client.PutAsync(Router.UpdateLegal(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
         }
 
-        public async Task<Organization> UpdateCustomizationAsync(string id, Dictionary<string, object> data)
+        public async Task<Organization> UpdateCustomizationAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateCustomization(id), content))
+            using (var response = await client.PutAsync(Router.UpdateCustomization(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
         }
 
-        public async Task<string> GetTestApiKeyAsync(string id)
+        public async Task<string> GetTestApiKeyAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.GetTestApiKey(id)))
+            using (var response = await client.GetAsync(Router.GetTestApiKey(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 return resultString;
             }
         }
 
 
-        public async Task<string> RenewTestApiKeyAsync(string id)
+        public async Task<string> RenewTestApiKeyAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(""))
-            using (var response = await client.PutAsync(Router.RenewTestApiKey(id), content))
+            using (var response = await client.PutAsync(Router.RenewTestApiKey(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 return resultString;
             }
         }
 
-        public async Task<LiveApiKey> ListLiveApiKeysAsync(string id)
+        public async Task<LiveApiKey> ListLiveApiKeysAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListAsyncLiveApiKeys(id)))
+            using (var response = await client.GetAsync(Router.ListAsyncLiveApiKeys(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var listResult = JsonConvert.DeserializeObject<LiveApiKey>(resultString, this.jsonSettings);
 
@@ -160,23 +161,23 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<string> RenewLiveApiKeyAsync(string id)
+        public async Task<string> RenewLiveApiKeyAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(""))
-            using (var response = await client.PutAsync(Router.RenewLiveApiKey(id), content))
+            using (var response = await client.PutAsync(Router.RenewLiveApiKey(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 return resultString;
             }
         }
 
 
-        public async Task<List<SeriesGroup>> ListSeriesGroupAsync(string id)
+        public async Task<List<SeriesGroup>> ListSeriesGroupAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListSeriesGroup(id)))
+            using (var response = await client.GetAsync(Router.ListSeriesGroup(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<List<SeriesGroup>>(resultString, this.jsonSettings);
@@ -184,58 +185,58 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<SeriesGroup> CreateSeriesGroupAsync(string id, Dictionary<string, object> data)
+        public async Task<SeriesGroup> CreateSeriesGroupAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.CreateSeriesGroup(id), content))
+            using (var response = await client.PutAsync(Router.CreateSeriesGroup(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
                 return series;
             }
         }
 
-        public async Task<SeriesGroup> UpdateSeriesGroupAsync(string id, string seriesName, Dictionary<string, object> data)
+        public async Task<SeriesGroup> UpdateSeriesGroupAsync(string id, string seriesName, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), content))
+            using (var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
                 return series;
             }
         }
         
-        public async Task<SeriesGroup> DeleteSeriesGroupAsync(string id, string seriesName)
+        public async Task<SeriesGroup> DeleteSeriesGroupAsync(string id, string seriesName, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.UpdateSeriesGroup(id, seriesName)))
+            using (var response = await client.DeleteAsync(Router.UpdateSeriesGroup(id, seriesName), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
                 return series;
             }
         }
         
-        public async Task<List<LiveApiKey>> DeleteLiveApiKeyAsync(string id, string apiKeyId)
+        public async Task<List<LiveApiKey>> DeleteLiveApiKeyAsync(string id, string apiKeyId, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteLiveApiKey(id, apiKeyId)))
+            using (var response = await client.DeleteAsync(Router.DeleteLiveApiKey(id, apiKeyId), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var deserializeJson = JsonConvert.DeserializeObject<List<LiveApiKey>>(resultString, this.jsonSettings);
                 return deserializeJson;
             }
         }
 
-        public async Task<Organization> UpdateSelfInvoiceSettingsAsync(string organizationId, Dictionary<string, object> data)
+        public async Task<Organization> UpdateSelfInvoiceSettingsAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateSelfInvoiceSettings(organizationId), content))
+            using (var response = await client.PutAsync(Router.UpdateSelfInvoiceSettings(organizationId), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;

--- a/Wrappers/OrganizationWrapper.cs
+++ b/Wrappers/OrganizationWrapper.cs
@@ -26,7 +26,7 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Organization> GetCurrentAsync(CancellationToken cancellationToken = default)
+        public async Task<Organization> MeAsync(CancellationToken cancellationToken = default)
         {
             using (var response = await client.GetAsync(Router.OrganizationMe(), cancellationToken))
             {
@@ -37,7 +37,7 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<DomainAvailability> CheckDomainAvailabilityAsync(string domain, CancellationToken cancellationToken = default)
+        public async Task<DomainAvailability> CheckDomainIsAvailableAsync(string domain, CancellationToken cancellationToken = default)
         {
             using (var response = await client.GetAsync(Router.CheckDomainAvailability(new Dictionary<string, object> { ["domain"] = domain }), cancellationToken))
             {
@@ -137,7 +137,7 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Organization> UpdateReceiptsAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        public async Task<Organization> UpdateReceiptSettingsAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateReceipts(id), content, cancellationToken))
@@ -219,7 +219,7 @@ namespace Facturapi.Wrappers
         }
 
 
-        public async Task<List<SeriesGroup>> ListSeriesGroupAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<List<SeriesGroup>> ListSeriesAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var response = await client.GetAsync(Router.ListSeriesGroup(id), cancellationToken))
             {
@@ -231,7 +231,7 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<SeriesGroup> CreateSeriesGroupAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        public async Task<SeriesGroup> CreateSeriesAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateSeriesGroup(id), content, cancellationToken))
@@ -243,7 +243,7 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<SeriesGroup> UpdateSeriesGroupAsync(string id, string seriesName, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        public async Task<SeriesGroup> UpdateSeriesAsync(string id, string seriesName, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), content, cancellationToken))
@@ -255,7 +255,7 @@ namespace Facturapi.Wrappers
             }
         }
         
-        public async Task<SeriesGroup> DeleteSeriesGroupAsync(string id, string seriesName, CancellationToken cancellationToken = default)
+        public async Task<SeriesGroup> DeleteSeriesAsync(string id, string seriesName, CancellationToken cancellationToken = default)
         {
             using (var response = await client.DeleteAsync(Router.UpdateSeriesGroup(id, seriesName), cancellationToken))
             {

--- a/Wrappers/ProductWrapper.cs
+++ b/Wrappers/ProductWrapper.cs
@@ -8,54 +8,66 @@ namespace Facturapi.Wrappers
 {
     public class ProductWrapper : BaseWrapper
     {
-        public ProductWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal ProductWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<SearchResult<Product>> ListAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.ListProducts(query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListProducts(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<SearchResult<Product>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<Product>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<Product> CreateAsync(Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.CreateProduct(), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
-            return customer;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateProduct(), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Product> RetrieveAsync(string id)
         {
-            var response = await client.GetAsync(Router.RetrieveProduct(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
-            return product;
+            using (var response = await client.GetAsync(Router.RetrieveProduct(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
+                return product;
+            }
         }
 
         public async Task<Product> DeleteAsync(string id)
         {
-            var response = await client.DeleteAsync(Router.DeleteProduct(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
-            return product;
+            using (var response = await client.DeleteAsync(Router.DeleteProduct(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
+                return product;
+            }
         }
 
 		public async Task<Product> UpdateAsync(string id, Dictionary<string, object> data)
 		{
-			var response = await client.PutAsync(Router.UpdateProduct(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-			var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
-			return product;
+			using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+			using (var response = await client.PutAsync(Router.UpdateProduct(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+			    var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
+			    return product;
+            }
 		}
     }
 }

--- a/Wrappers/ProductWrapper.cs
+++ b/Wrappers/ProductWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -12,11 +13,11 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<Product>> ListAsync(Dictionary<string, object> query = null)
+        public async Task<SearchResult<Product>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListProducts(query)))
+            using (var response = await client.GetAsync(Router.ListProducts(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Product>>(resultString, this.jsonSettings);
@@ -24,46 +25,46 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Product> CreateAsync(Dictionary<string, object> data)
+        public async Task<Product> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateProduct(), content))
+            using (var response = await client.PostAsync(Router.CreateProduct(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Product> RetrieveAsync(string id)
+        public async Task<Product> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveProduct(id)))
+            using (var response = await client.GetAsync(Router.RetrieveProduct(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
                 return product;
             }
         }
 
-        public async Task<Product> DeleteAsync(string id)
+        public async Task<Product> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteProduct(id)))
+            using (var response = await client.DeleteAsync(Router.DeleteProduct(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
                 return product;
             }
         }
 
-		public async Task<Product> UpdateAsync(string id, Dictionary<string, object> data)
+		public async Task<Product> UpdateAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
 		{
 			using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-			using (var response = await client.PutAsync(Router.UpdateProduct(id), content))
+			using (var response = await client.PutAsync(Router.UpdateProduct(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 			    var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
 			    return product;

--- a/Wrappers/ReceiptWrapper.cs
+++ b/Wrappers/ReceiptWrapper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -13,11 +14,11 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<Receipt>> ListAsync(Dictionary<string, object> query = null)
+        public async Task<SearchResult<Receipt>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListReceipts(query)))
+            using (var response = await client.GetAsync(Router.ListReceipts(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Receipt>>(resultString, this.jsonSettings);
@@ -25,75 +26,75 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Receipt> CreateAsync(Dictionary<string, object> data)
+        public async Task<Receipt> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateReceipt(), content))
+            using (var response = await client.PostAsync(Router.CreateReceipt(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Receipt> RetrieveAsync(string id)
+        public async Task<Receipt> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveReceipt(id)))
+            using (var response = await client.GetAsync(Router.RetrieveReceipt(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Receipt> CancelAsync(string id)
+        public async Task<Receipt> CancelAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.CancelInvoice(id)))
+            using (var response = await client.DeleteAsync(Router.CancelInvoice(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task InvoiceAsync(string id, Dictionary<string, object> data)
+        public async Task InvoiceAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.InvoiceReceipt(id), content))
+            using (var response = await client.PostAsync(Router.InvoiceReceipt(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
             }
         }
 
-        public async Task CreateGlobalInvoiceAsync(string id, Dictionary<string, object> data)
+        public async Task CreateGlobalInvoiceAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateGlobalInvoice(id), content))
+            using (var response = await client.PostAsync(Router.CreateGlobalInvoice(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
             }
         }
 
-        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
+        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendReceiptByEmail(id), content))
+            using (var response = await client.PostAsync(Router.SendReceiptByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
             }
         }
 
-        public async Task<Stream> DownloadPdfAsync(string id)
+        public async Task<Stream> DownloadPdfAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.DownloadReceiptPdf(id)))
+            using (var response = await client.GetAsync(Router.DownloadReceiptPdf(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var responseStream = await response.Content.ReadAsStreamAsync();
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
                 memory.Position = 0;
                 return memory;
             }

--- a/Wrappers/ReceiptWrapper.cs
+++ b/Wrappers/ReceiptWrapper.cs
@@ -9,71 +9,94 @@ namespace Facturapi.Wrappers
 {
     public class ReceiptWrapper : BaseWrapper
     {
-        public ReceiptWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal ReceiptWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<SearchResult<Receipt>> ListAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.ListReceipts(query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListReceipts(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<SearchResult<Receipt>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<Receipt>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<Receipt> CreateAsync(Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.CreateReceipt(), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
-            return customer;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateReceipt(), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Receipt> RetrieveAsync(string id)
         {
-            var response = await client.GetAsync(Router.RetrieveReceipt(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
-            return customer;
+            using (var response = await client.GetAsync(Router.RetrieveReceipt(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Receipt> CancelAsync(string id)
         {
-            var response = await client.DeleteAsync(Router.CancelInvoice(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
-            return customer;
+            using (var response = await client.DeleteAsync(Router.CancelInvoice(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task InvoiceAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.InvoiceReceipt(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.InvoiceReceipt(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+            }
         }
 
         public async Task CreateGlobalInvoiceAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.CreateGlobalInvoice(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateGlobalInvoice(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+            }
         }
 
         public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
         {
-            var response = await client.PostAsync(Router.SendReceiptByEmail(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.SendReceiptByEmail(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+            }
         }
 
         public async Task<Stream> DownloadPdfAsync(string id)
         {
-            var response = await client.GetAsync(Router.DownloadReceiptPdf(id));
-            await this.ThrowIfErrorAsync(response);
-            var stream = await response.Content.ReadAsStreamAsync();
-            return stream;
+            using (var response = await client.GetAsync(Router.DownloadReceiptPdf(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var responseStream = await response.Content.ReadAsStreamAsync();
+                var memory = new MemoryStream();
+                await responseStream.CopyToAsync(memory);
+                memory.Position = 0;
+                return memory;
+            }
         }
     }
 }

--- a/Wrappers/ReceiptWrapper.cs
+++ b/Wrappers/ReceiptWrapper.cs
@@ -51,7 +51,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Receipt> CancelAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.CancelInvoice(id), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.CancelReceipt(id), cancellationToken))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
@@ -69,10 +69,10 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task CreateGlobalInvoiceAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        public async Task CreateGlobalInvoiceAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateGlobalInvoice(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateGlobalInvoice(), content, cancellationToken))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken);
             }

--- a/Wrappers/RetentionWrapper.cs
+++ b/Wrappers/RetentionWrapper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -13,11 +14,11 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null)
+        public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListRetentionss(query)))
+            using (var response = await client.GetAsync(Router.ListRetentionss(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
@@ -25,75 +26,75 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Invoice> CreateAsync(Dictionary<string, object> data)
+        public async Task<Invoice> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateRetention(), content))
+            using (var response = await client.PostAsync(Router.CreateRetention(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Invoice> RetrieveAsync(string id)
+        public async Task<Invoice> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveRetention(id)))
+            using (var response = await client.GetAsync(Router.RetrieveRetention(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Invoice> CancelAsync(string id)
+        public async Task<Invoice> CancelAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.CancelRetention(id)))
+            using (var response = await client.DeleteAsync(Router.CancelRetention(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
+        public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendRetentionByEmail(id), content))
+            using (var response = await client.PostAsync(Router.SendRetentionByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
             }
         }
 
-        private async Task<Stream> DownloadAsync(string id, string format)
+        private async Task<Stream> DownloadAsync(string id, string format, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(Router.DownloadRetention(id, format)))
+            using (var response = await client.GetAsync(Router.DownloadRetention(id, format), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var responseStream = await response.Content.ReadAsStreamAsync();
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
                 memory.Position = 0;
                 return memory;
             }
         }
 
-        public Task<Stream> DownloadZipAsync(string id)
+        public Task<Stream> DownloadZipAsync(string id, CancellationToken cancellationToken = default)
         {
-            return this.DownloadAsync(id, "zip");
+            return this.DownloadAsync(id, "zip", cancellationToken);
         }
 
-        public Task<Stream> DownloadPdfAsync(string id)
+        public Task<Stream> DownloadPdfAsync(string id, CancellationToken cancellationToken = default)
         {
-            return this.DownloadAsync(id, "pdf");
+            return this.DownloadAsync(id, "pdf", cancellationToken);
         }
 
-        public Task<Stream> DownloadXmlAsync(string id)
+        public Task<Stream> DownloadXmlAsync(string id, CancellationToken cancellationToken = default)
         {
-            return this.DownloadAsync(id, "xml");
+            return this.DownloadAsync(id, "xml", cancellationToken);
         }
     }
 }

--- a/Wrappers/RetentionWrapper.cs
+++ b/Wrappers/RetentionWrapper.cs
@@ -9,59 +9,76 @@ namespace Facturapi.Wrappers
 {
     public class RetentionWrapper : BaseWrapper
     {
-        public RetentionWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal RetentionWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.ListRetentionss(query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListRetentionss(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<Invoice> CreateAsync(Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.CreateRetention(), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return customer;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateRetention(), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Invoice> RetrieveAsync(string id)
         {
-            var response = await client.GetAsync(Router.RetrieveRetention(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return customer;
+            using (var response = await client.GetAsync(Router.RetrieveRetention(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task<Invoice> CancelAsync(string id)
         {
-            var response = await client.DeleteAsync(Router.CancelRetention(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
-            return customer;
+            using (var response = await client.DeleteAsync(Router.CancelRetention(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
+                return customer;
+            }
         }
 
         public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null)
         {
-            var response = await client.PostAsync(Router.SendRetentionByEmail(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.SendRetentionByEmail(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+            }
         }
 
         private async Task<Stream> DownloadAsync(string id, string format)
         {
-            var response = await client.GetAsync(Router.DownloadRetention(id, format));
-            await this.ThrowIfErrorAsync(response);
-            var stream = await response.Content.ReadAsStreamAsync();
-            return stream;
+            using (var response = await client.GetAsync(Router.DownloadRetention(id, format)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var responseStream = await response.Content.ReadAsStreamAsync();
+                var memory = new MemoryStream();
+                await responseStream.CopyToAsync(memory);
+                memory.Position = 0;
+                return memory;
+            }
         }
 
         public Task<Stream> DownloadZipAsync(string id)

--- a/Wrappers/ToolWrapper.cs
+++ b/Wrappers/ToolWrapper.cs
@@ -1,30 +1,31 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Facturapi.Wrappers
 {
     public class ToolWrapper : BaseWrapper
     {
-        public ToolWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal ToolWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<TaxIdValidation> ValidateTaxId(string taxId)
         {
-            var response = await client.GetAsync(Router.ValidateTaxId(
+            using (var response = await client.GetAsync(Router.ValidateTaxId(
                 new Dictionary<string, object>()
                 {
                     ["tax_id"] = taxId
                 }
-            ));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            )))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var result = JsonConvert.DeserializeObject<TaxIdValidation>(resultString, this.jsonSettings);
-            return result;
+                var result = JsonConvert.DeserializeObject<TaxIdValidation>(resultString, this.jsonSettings);
+                return result;
+            }
         }
     }
 }

--- a/Wrappers/ToolWrapper.cs
+++ b/Wrappers/ToolWrapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -11,16 +12,16 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<TaxIdValidation> ValidateTaxId(string taxId)
+        public async Task<TaxIdValidation> ValidateTaxId(string taxId, CancellationToken cancellationToken = default)
         {
             using (var response = await client.GetAsync(Router.ValidateTaxId(
                 new Dictionary<string, object>()
                 {
                     ["tax_id"] = taxId
                 }
-            )))
+            ), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var result = JsonConvert.DeserializeObject<TaxIdValidation>(resultString, this.jsonSettings);

--- a/Wrappers/ToolWrapper.cs
+++ b/Wrappers/ToolWrapper.cs
@@ -28,5 +28,27 @@ namespace Facturapi.Wrappers
                 return result;
             }
         }
+
+        public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.HealthCheck(), cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var result = JsonConvert.DeserializeObject<Dictionary<string, object>>(resultString, this.jsonSettings);
+                if (result != null && result.TryGetValue("ok", out var okValue))
+                {
+                    if (okValue is bool okBool)
+                    {
+                        return okBool;
+                    }
+                    if (bool.TryParse(okValue.ToString(), out var parsed))
+                    {
+                        return parsed;
+                    }
+                }
+                return false;
+            }
+        }
     }
 }

--- a/Wrappers/ToolWrapper.cs
+++ b/Wrappers/ToolWrapper.cs
@@ -12,7 +12,7 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<TaxIdValidation> ValidateTaxId(string taxId, CancellationToken cancellationToken = default)
+        public async Task<TaxIdValidation> ValidateTaxIdAsync(string taxId, CancellationToken cancellationToken = default)
         {
             using (var response = await client.GetAsync(Router.ValidateTaxId(
                 new Dictionary<string, object>()

--- a/Wrappers/WebhookWrapper.cs
+++ b/Wrappers/WebhookWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Facturapi.Wrappers
 {
@@ -12,11 +13,11 @@ namespace Facturapi.Wrappers
         {
         }
 
-        public async Task<SearchResult<Webhook>> ListAsync(Dictionary<string, object> query = null)
+        public async Task<SearchResult<Webhook>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListWebhooks(query)))
+            using (var response = await client.GetAsync(Router.ListWebhooks(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Webhook>>(resultString, this.jsonSettings);
@@ -24,58 +25,58 @@ namespace Facturapi.Wrappers
             }
         }
 
-        public async Task<Webhook> CreateAsync(Dictionary<string, object> data)
+        public async Task<Webhook> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateWebhook(), content))
+            using (var response = await client.PostAsync(Router.CreateWebhook(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;
             }
         }
 
-        public async Task<Webhook> RetrieveAsync(string id)
+        public async Task<Webhook> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveWebhook(id)))
+            using (var response = await client.GetAsync(Router.RetrieveWebhook(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;
             }
         }
 
-        public async Task<Webhook> UpdateAsync(string id, Dictionary<string, object> data)
-        {
-            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateWebhook(id), content))
-            {
-                await this.ThrowIfErrorAsync(response);
-                var resultString = await response.Content.ReadAsStringAsync();
-                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
-                return webhook;
-            }
-        }
-
-        public async Task<Webhook> DeleteAsync(string id)
-        {
-            using (var response = await client.DeleteAsync(Router.DeleteWebhook(id)))
-            {
-                await this.ThrowIfErrorAsync(response);
-                var resultString = await response.Content.ReadAsStringAsync();
-                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
-                return webhook;
-            }
-        }
-
-        public async Task<Webhook> ValidateSignatureAsync(Dictionary<string, object> data)
+        public async Task<Webhook> UpdateAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.ValidateSignature(), content))
+            using (var response = await client.PutAsync(Router.UpdateWebhook(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response);
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
+                return webhook;
+            }
+        }
+
+        public async Task<Webhook> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.DeleteAsync(Router.DeleteWebhook(id), cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
+                return webhook;
+            }
+        }
+
+        public async Task<Webhook> ValidateSignatureAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.ValidateSignature(), content, cancellationToken))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken);
                 var resultString = await response.Content.ReadAsStringAsync();
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;

--- a/Wrappers/WebhookWrapper.cs
+++ b/Wrappers/WebhookWrapper.cs
@@ -8,63 +8,78 @@ namespace Facturapi.Wrappers
 {
     public class WebhookWrapper : BaseWrapper
     {
-        public WebhookWrapper(string apiKey, string apiVersion = "v2") : base(apiKey, apiVersion)
+        internal WebhookWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
         }
 
         public async Task<SearchResult<Webhook>> ListAsync(Dictionary<string, object> query = null)
         {
-            var response = await client.GetAsync(Router.ListWebhooks(query));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
+            using (var response = await client.GetAsync(Router.ListWebhooks(query)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
 
-            var searchResult = JsonConvert.DeserializeObject<SearchResult<Webhook>>(resultString, this.jsonSettings);
-            return searchResult;
+                var searchResult = JsonConvert.DeserializeObject<SearchResult<Webhook>>(resultString, this.jsonSettings);
+                return searchResult;
+            }
         }
 
         public async Task<Webhook> CreateAsync(Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.CreateWebhook(), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
-            return webhook;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.CreateWebhook(), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
+                return webhook;
+            }
         }
 
         public async Task<Webhook> RetrieveAsync(string id)
         {
-            var response = await client.GetAsync(Router.RetrieveWebhook(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
-            return webhook;
+            using (var response = await client.GetAsync(Router.RetrieveWebhook(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
+                return webhook;
+            }
         }
 
         public async Task<Webhook> UpdateAsync(string id, Dictionary<string, object> data)
         {
-            var response = await client.PutAsync(Router.UpdateWebhook(id), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
-            return webhook;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateWebhook(id), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
+                return webhook;
+            }
         }
 
         public async Task<Webhook> DeleteAsync(string id)
         {
-            var response = await client.DeleteAsync(Router.DeleteWebhook(id));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
-            return webhook;
+            using (var response = await client.DeleteAsync(Router.DeleteWebhook(id)))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
+                return webhook;
+            }
         }
 
         public async Task<Webhook> ValidateSignatureAsync(Dictionary<string, object> data)
         {
-            var response = await client.PostAsync(Router.ValidateSignature(), new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"));
-            await this.ThrowIfErrorAsync(response);
-            var resultString = await response.Content.ReadAsStringAsync();
-            var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
-            return webhook;
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.ValidateSignature(), content))
+            {
+                await this.ThrowIfErrorAsync(response);
+                var resultString = await response.Content.ReadAsStringAsync();
+                var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
+                return webhook;
+            }
         }
 
     }

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -11,7 +11,7 @@
       API Keys creando una cuenta gratuita en https://www.facturapi.io</Summary>
     <PackageTags>factura factura-electronica cfdi facturapi mexico conekta</PackageTags>
     <Title>Facturapi</Title>
-    <Version>4.11.0</Version>
+    <Version>5.0.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Owners>Facturapi</Owners>
     <ApplicationIcon>facturapi.ico</ApplicationIcon>


### PR DESCRIPTION
This pull request introduces several breaking changes and new features in preparation for version 5.0.0. The main focus is on improving testability, resource management, and request cancellation support across the client library. The most significant updates include making wrapper constructors internal, introducing a new client interface for easier mocking, implementing `IDisposable` for proper HTTP resource cleanup, and adding optional `CancellationToken` parameters to client methods.

### Breaking changes and API surface improvements
* Wrapper classes (e.g., `CustomerWrapper`, `ProductWrapper`) can no longer be constructed directly; their constructors are now internal and require an `HttpClient` instance, enforcing usage through `FacturapiClient`. (`FacturapiClient.cs`, `Wrappers/CustomerWrapper.cs`, `Wrappers/CatalogWrapper.cs`, [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R22) [[2]](diffhunk://#diff-3b5e0c9bdc470ba2d882aac2733acf58d247dfea145a9a06db426c4a62611b5eR6-R91) [[3]](diffhunk://#diff-5b694ac7c556ff4a71eff5b919953e608916b3ca91919b6fcb0646bc11bada27R5-R80)
* Introduced the `IFacturapiClient` interface, allowing consumers to mock the client for testing purposes. (`IFacturapiClient.cs`, [IFacturapiClient.csR1-R18](diffhunk://#diff-79e0c16a8e0d193cd7163cdff00b5ae3f3743004642aea79d79f823a0babbe12R1-R18))
* `FacturapiClient` now implements `IDisposable`. Consumers should call `Dispose()` or use a `using` statement to ensure HTTP resources are released promptly. (`FacturapiClient.cs`, [[1]](diffhunk://#diff-dfe6bf27485f8665480bdc6d40a4737f0439c9ed611fdf5c41cdb685365155a0R19-R43) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R22)

### Request cancellation and async improvements
* All async methods in wrapper classes now accept optional `CancellationToken` parameters, enabling callers to cancel in-flight requests. (`Wrappers/CustomerWrapper.cs`, `Wrappers/CatalogWrapper.cs`, [[1]](diffhunk://#diff-3b5e0c9bdc470ba2d882aac2733acf58d247dfea145a9a06db426c4a62611b5eR6-R91) [[2]](diffhunk://#diff-5b694ac7c556ff4a71eff5b919953e608916b3ca91919b6fcb0646bc11bada27R5-R80)
* Internal HTTP calls and error handling have been updated to propagate cancellation tokens and throw if cancellation is requested. (`Wrappers/BaseWrapper.cs`, [[1]](diffhunk://#diff-2bf8ac70495ba1de56ed48e69c34e31dfd850cf3cb4bf4c81f07e01d9e909b3aR7-R23) [[2]](diffhunk://#diff-2bf8ac70495ba1de56ed48e69c34e31dfd850cf3cb4bf4c81f07e01d9e909b3aL75-R76)

### Documentation and versioning
* Updated `CHANGELOG.md` to reflect the new version (5.0.0), highlight breaking changes, and document the new features and improvements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R22) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL68-R78)