### PR TITLE
chore: use NuGet OIDC login

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout code
@@ -45,6 +48,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
         if: steps.version-check.outputs.exists == 'false'
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
- enable OIDC permissions for GitHub Actions
- add `NuGet/login@v1` to mint a temporary NuGet API key
- publish using the OIDC-generated API key

## Environment / Secrets
- **Added**: `NUGET_USER` (NuGet.org username)
- **Removed**: `NUGET_API_KEY` (no longer needed with Trusted Publishing)

## Notes
- Make sure Trusted Publishing is configured in NuGet.org for this repo and workflow.