### PR TITLE
feat!: modernize SDK contract, add CI tests, and improve migration docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build facturapi-net.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test FacturapiTest/FacturapiTest.csproj --configuration Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,9 +18,35 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build facturapi-net.sln --configuration Release --no-restore
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test_framework: net6.0
+            runtime_version: 6.0.x
+          - test_framework: net8.0
+            runtime_version: 8.0.x
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
           dotnet-version: |
-            6.0.x
             10.0.x
+            ${{ matrix.runtime_version }}
 
       - name: Restore dependencies
         run: dotnet restore
@@ -29,4 +55,4 @@ jobs:
         run: dotnet build facturapi-net.sln --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test FacturapiTest/FacturapiTest.csproj --configuration Release --no-build
+        run: dotnet test FacturapiTest/FacturapiTest.csproj --framework ${{ matrix.test_framework }} --configuration Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: |
+            6.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
+            8.0.x
             10.0.x
 
       - name: Restore dependencies
@@ -30,7 +31,9 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test FacturapiTest/FacturapiTest.csproj --configuration Release --no-build
+        run: |
+          dotnet test FacturapiTest/FacturapiTest.csproj --framework net6.0 --configuration Release --no-build
+          dotnet test FacturapiTest/FacturapiTest.csproj --framework net8.0 --configuration Release --no-build
 
       - name: Pack
         run: dotnet pack --configuration Release --no-build --output ./nupkg

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "10.0.x" # Adjust the .NET version as needed
+          dotnet-version: |
+            6.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
+      - name: Test
+        run: dotnet test FacturapiTest/FacturapiTest.csproj --configuration Release --no-build
+
       - name: Pack
         run: dotnet pack --configuration Release --no-build --output ./nupkg
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ ICustomerWrapper customers = client.Customer;
 - `Invoice.StampDraftAsync` and legacy `StampDraft` now co-exist; `StampDraft` is marked as obsolete.
 - Added initial `FacturapiTest` test project with regression coverage for query building and wrapper behavior.
 - Added `FacturapiClient.CreateWithCustomHttpClient(...)` for advanced scenarios where consumers need to provide their own `HttpClient` without changing the default constructor.
+- Added organization team-management endpoints to `Organization` / `IOrganizationWrapper`: access listing and retrieval, invite send/cancel/respond flows, role listing/templates/operations, role CRUD, and role reassignment for team members.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-03-30
+
+### Migration Guide
+
+No changes are required if your code:
+- Instantiates `FacturapiClient` and calls wrapper methods directly (for example `await client.Invoice.CreateAsync(...)`).
+- Uses `var` when storing wrapper properties (for example `var invoices = client.Invoice;`).
+- Does not depend on concrete wrapper types in method signatures, fields, or tests.
+
+You need to update your code if you:
+- Type wrapper properties as concrete classes (`CustomerWrapper`, `InvoiceWrapper`, etc.).
+- Mock or inject concrete wrapper classes.
+- Expose concrete wrappers in your own interfaces or public APIs.
+
+Before (v5):
+```csharp
+CustomerWrapper customers = client.Customer;
+```
+
+After (v6):
+```csharp
+ICustomerWrapper customers = client.Customer;
+```
+
+### Breaking
+
+- `IFacturapiClient` now exposes wrapper interfaces instead of concrete wrapper classes:
+  - `ICustomerWrapper`, `IProductWrapper`, `IInvoiceWrapper`, `IOrganizationWrapper`, `IReceiptWrapper`, `IRetentionWrapper`, `ICatalogWrapper`, `ICartaporteCatalogWrapper`, `IToolWrapper`, `IWebhookWrapper`.
+- `FacturapiClient` properties now return those interface types as part of the public contract.
+- Dropped `net452` target framework support. The package now targets `netstandard2.0`, `net6.0`, and `net8.0`.
+
+### Added
+
+- New public interfaces for all wrapper surfaces to improve dependency injection and mocking in tests.
+- `Invoice.StampDraftAsync` and legacy `StampDraft` now co-exist; `StampDraft` is marked as obsolete.
+- Added initial `FacturapiTest` test project with regression coverage for query building and wrapper behavior.
+- Added `FacturapiClient.CreateWithCustomHttpClient(...)` for advanced scenarios where consumers need to provide their own `HttpClient` without changing the default constructor.
+
+### Fixed
+
+- `Retention.CancelAsync` is now consistent with the rest of the SDK: supports `CancellationToken`, disposes HTTP responses, and uses shared error handling (`ThrowIfErrorAsync`).
+- Query string generation now handles null values and empty query dictionaries safely.
+- README examples were corrected to align with the current async API surface and valid C# snippets.
+- Internal async calls in wrapper implementations now consistently use `ConfigureAwait(false)`.
+
 ## [5.1.0] - 2026-03-12
 
 ### Fix

--- a/FacturapiClient.cs
+++ b/FacturapiClient.cs
@@ -72,9 +72,7 @@ namespace Facturapi
 
         private static HttpClient CreateDefaultHttpClient(string apiKey, string apiVersion)
         {
-            var client = new HttpClient();
-            ConfigureHttpClient(client, apiKey, apiVersion);
-            return client;
+            return new HttpClient();
         }
 
         private static void ConfigureHttpClient(HttpClient client, string apiKey, string apiVersion)

--- a/FacturapiClient.cs
+++ b/FacturapiClient.cs
@@ -8,27 +8,30 @@ namespace Facturapi
 {
     public sealed class FacturapiClient : IFacturapiClient
     {
-        public CustomerWrapper Customer { get; private set; }
-        public ProductWrapper Product { get; private set; }
-        public InvoiceWrapper Invoice { get; private set; }
-        public OrganizationWrapper Organization { get; private set; }
-        public ReceiptWrapper Receipt { get; private set; }
-        public RetentionWrapper Retention { get; private set; }
-        public CatalogWrapper Catalog { get; private set; }
-        public CartaporteCatalogWrapper CartaporteCatalog { get; private set; }
-        public ToolWrapper Tool { get; private set; }
-        public WebhookWrapper Webhook { get; private set; }
+        public ICustomerWrapper Customer { get; private set; }
+        public IProductWrapper Product { get; private set; }
+        public IInvoiceWrapper Invoice { get; private set; }
+        public IOrganizationWrapper Organization { get; private set; }
+        public IReceiptWrapper Receipt { get; private set; }
+        public IRetentionWrapper Retention { get; private set; }
+        public ICatalogWrapper Catalog { get; private set; }
+        public ICartaporteCatalogWrapper CartaporteCatalog { get; private set; }
+        public IToolWrapper Tool { get; private set; }
+        public IWebhookWrapper Webhook { get; private set; }
         private readonly HttpClient httpClient;
+        private readonly bool ownsHttpClient;
         private bool disposed;
 
         public FacturapiClient(string apiKey, string apiVersion = "v2")
+            : this(apiKey, apiVersion, CreateDefaultHttpClient(apiKey, apiVersion), ownsHttpClient: true)
         {
-            var apiKeyBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey + ":"));
-            this.httpClient = new HttpClient
-            {
-                BaseAddress = new Uri($"https://www.facturapi.io/{apiVersion}/")
-            };
-            this.httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", apiKeyBase64);
+        }
+
+        private FacturapiClient(string apiKey, string apiVersion, HttpClient httpClient, bool ownsHttpClient)
+        {
+            this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            this.ownsHttpClient = ownsHttpClient;
+            ConfigureHttpClient(this.httpClient, apiKey, apiVersion);
 
             this.Customer = new CustomerWrapper(apiKey, apiVersion, this.httpClient);
             this.Product = new ProductWrapper(apiKey, apiVersion, this.httpClient);
@@ -42,6 +45,16 @@ namespace Facturapi
             this.Webhook = new WebhookWrapper(apiKey, apiVersion, this.httpClient);
         }
 
+        public static FacturapiClient CreateWithCustomHttpClient(string apiKey, HttpClient httpClient, string apiVersion = "v2")
+        {
+            if (httpClient == null)
+            {
+                throw new ArgumentNullException(nameof(httpClient));
+            }
+
+            return new FacturapiClient(apiKey, apiVersion, httpClient, ownsHttpClient: false);
+        }
+
         public void Dispose()
         {
             if (this.disposed)
@@ -49,9 +62,26 @@ namespace Facturapi
                 return;
             }
 
-            this.httpClient?.Dispose();
+            if (this.ownsHttpClient)
+            {
+                this.httpClient.Dispose();
+            }
             this.disposed = true;
             GC.SuppressFinalize(this);
+        }
+
+        private static HttpClient CreateDefaultHttpClient(string apiKey, string apiVersion)
+        {
+            var client = new HttpClient();
+            ConfigureHttpClient(client, apiKey, apiVersion);
+            return client;
+        }
+
+        private static void ConfigureHttpClient(HttpClient client, string apiKey, string apiVersion)
+        {
+            var apiKeyBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey + ":"));
+            client.BaseAddress = new Uri($"https://www.facturapi.io/{apiVersion}/");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", apiKeyBase64);
         }
     }
 }

--- a/FacturapiTest/ClientCompatibilityTests.cs
+++ b/FacturapiTest/ClientCompatibilityTests.cs
@@ -1,0 +1,125 @@
+using Facturapi;
+using Facturapi.Wrappers;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FacturapiTest
+{
+    public class ClientCompatibilityTests
+    {
+        [Fact]
+        public void Router_ListCustomers_AllowsNullQueryValues()
+        {
+            var query = new Dictionary<string, object>
+            {
+                ["foo"] = null!,
+                [""] = "ignored"
+            };
+
+            var url = Router.ListCustomers(query);
+
+            Assert.Equal("customers?foo=", url);
+        }
+
+        [Fact]
+        public async Task RetentionCancelAsync_ThrowsFacturapiExceptionWithStatus()
+        {
+            var handler = new StubHttpMessageHandler((request, cancellationToken) =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("{\"message\":\"bad retention\",\"status\":400}", Encoding.UTF8, "application/json")
+                };
+                return Task.FromResult(response);
+            });
+
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://www.facturapi.io/v2/")
+            };
+            var wrapper = new RetentionWrapper("test_key", "v2", httpClient);
+
+            var exception = await Assert.ThrowsAsync<FacturapiException>(() =>
+                wrapper.CancelAsync("ret_123", cancellationToken: CancellationToken.None));
+
+            Assert.Equal(400, exception.Status);
+            Assert.Equal("bad retention", exception.Message);
+        }
+
+        [Fact]
+        public async Task InvoiceStampDraftAsync_AndLegacyMethod_BothWork()
+        {
+            var handler = new StubHttpMessageHandler((request, cancellationToken) =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"id\":\"inv_123\"}", Encoding.UTF8, "application/json")
+                };
+                return Task.FromResult(response);
+            });
+
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://www.facturapi.io/v2/")
+            };
+            var wrapper = new InvoiceWrapper("test_key", "v2", httpClient);
+
+            var fromAsync = await wrapper.StampDraftAsync("inv_123");
+#pragma warning disable CS0618
+            var fromLegacy = await wrapper.StampDraft("inv_123");
+#pragma warning restore CS0618
+
+            Assert.Equal("inv_123", fromAsync.Id);
+            Assert.Equal("inv_123", fromLegacy.Id);
+        }
+
+        [Fact]
+        public async Task CreateWithCustomHttpClient_DoesNotDisposeInjectedClient()
+        {
+            var handler = new StubHttpMessageHandler((request, cancellationToken) =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"ok\":true}", Encoding.UTF8, "application/json")
+                };
+                return Task.FromResult(response);
+            });
+
+            var injectedHttpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://www.facturapi.io/v2/")
+            };
+
+            var client = FacturapiClient.CreateWithCustomHttpClient("test_key", injectedHttpClient, "v2");
+
+            var healthy = await client.Tool.HealthCheckAsync();
+            Assert.True(healthy);
+
+            client.Dispose();
+
+            var response = await injectedHttpClient.GetAsync("check");
+            Assert.True(response.IsSuccessStatusCode);
+        }
+
+        private sealed class StubHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+            public StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+            {
+                this.handler = handler;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return this.handler(request, cancellationToken);
+            }
+        }
+    }
+}

--- a/FacturapiTest/FacturapiTest.csproj
+++ b/FacturapiTest/FacturapiTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/FacturapiTest/FacturapiTest.csproj
+++ b/FacturapiTest/FacturapiTest.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\facturapi-net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FacturapiTest/WrapperBehaviorTests.cs
+++ b/FacturapiTest/WrapperBehaviorTests.cs
@@ -72,6 +72,129 @@ namespace FacturapiTest
         }
 
         [Fact]
+        public async Task OrganizationListTeamAccessAsync_UsesTeamRoute()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/organizations/org_1/team", request.RequestUri.PathAndQuery);
+                return Task.FromResult(JsonResponse("[]"));
+            });
+
+            var wrapper = new OrganizationWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.ListTeamAccessAsync("org_1");
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task OrganizationInviteUserToTeamAsync_UsesInvitesRoute()
+        {
+            var handler = new RecordingHandler(async (request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Post, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/organizations/org_1/team/invites", request.RequestUri.PathAndQuery);
+                Assert.NotNull(request.Content);
+                var body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Assert.Contains("\"email\":\"dev@example.com\"", body);
+
+                return JsonResponse("{\"id\":\"inv_001\",\"email\":\"dev@example.com\"}");
+            });
+
+            var wrapper = new OrganizationWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.InviteUserToTeamAsync("org_1", new Dictionary<string, object>
+            {
+                ["email"] = "dev@example.com"
+            });
+
+            Assert.Equal("inv_001", result.Id);
+        }
+
+        [Fact]
+        public async Task OrganizationListTeamRoleOperationsAsync_UsesOperationsRoute()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/organizations/org_1/team/roles/operations", request.RequestUri.PathAndQuery);
+                return Task.FromResult(JsonResponse("[\"invoice:list\"]"));
+            });
+
+            var wrapper = new OrganizationWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.ListTeamRoleOperationsAsync("org_1");
+
+            Assert.Single(result);
+            Assert.Equal("invoice:list", result[0]);
+        }
+
+        [Fact]
+        public async Task OrganizationRemoveTeamAccessAsync_ParsesOkResponse()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Delete, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/organizations/org_1/team/acc_1", request.RequestUri.PathAndQuery);
+                return Task.FromResult(JsonResponse("{\"ok\":true}"));
+            });
+
+            var wrapper = new OrganizationWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.RemoveTeamAccessAsync("org_1", "acc_1");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task OrganizationRespondTeamInviteAsync_UsesInviteResponseRoute()
+        {
+            var handler = new RecordingHandler(async (request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Post, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/organizations/invites/inv_1/response", request.RequestUri.PathAndQuery);
+                Assert.NotNull(request.Content);
+                var body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Assert.Contains("\"accept\":true", body);
+                return JsonResponse("{\"ok\":true}");
+            });
+
+            var wrapper = new OrganizationWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.RespondTeamInviteAsync("inv_1", new Dictionary<string, object>
+            {
+                ["accept"] = true
+            });
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task OrganizationUpdateTeamRoleAsync_UsesRoleRoute()
+        {
+            var handler = new RecordingHandler(async (request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Put, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/organizations/org_1/team/roles/role_1", request.RequestUri.PathAndQuery);
+                Assert.NotNull(request.Content);
+                var body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Assert.Contains("\"name\":\"Senior billing analyst\"", body);
+                return JsonResponse("{\"id\":\"role_1\",\"name\":\"Senior billing analyst\"}");
+            });
+
+            var wrapper = new OrganizationWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.UpdateTeamRoleAsync("org_1", "role_1", new Dictionary<string, object>
+            {
+                ["name"] = "Senior billing analyst"
+            });
+
+            Assert.Equal("role_1", result.Id);
+            Assert.Equal("Senior billing analyst", result.Name);
+        }
+
+        [Fact]
         public async Task RetentionListAsync_UsesRetentionsRoute()
         {
             var handler = new RecordingHandler((request, cancellationToken) =>

--- a/FacturapiTest/WrapperBehaviorTests.cs
+++ b/FacturapiTest/WrapperBehaviorTests.cs
@@ -1,0 +1,240 @@
+using Facturapi;
+using Facturapi.Wrappers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FacturapiTest
+{
+    public class WrapperBehaviorTests
+    {
+        [Fact]
+        public async Task InvoiceCreateAsync_UsesPostAndQueryString()
+        {
+            var handler = new RecordingHandler(async (request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Post, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/invoices?foo=bar", request.RequestUri.PathAndQuery);
+                Assert.NotNull(request.Content);
+                var body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Assert.Contains("\"field\":\"value\"", body);
+
+                return JsonResponse("{\"id\":\"inv_001\"}");
+            });
+
+            var wrapper = new InvoiceWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.CreateAsync(
+                new Dictionary<string, object> { ["field"] = "value" },
+                new Dictionary<string, object> { ["foo"] = "bar" });
+
+            Assert.Equal("inv_001", result.Id);
+        }
+
+        [Fact]
+        public async Task ReceiptCancelAsync_UsesReceiptDeleteRoute()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Delete, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/receipts/rcp_123", request.RequestUri.PathAndQuery);
+                return Task.FromResult(JsonResponse("{\"id\":\"rcp_123\"}"));
+            });
+
+            var wrapper = new ReceiptWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.CancelAsync("rcp_123");
+
+            Assert.Equal("rcp_123", result.Id);
+        }
+
+        [Fact]
+        public async Task OrganizationDeleteSeriesAsync_UsesDeleteSeriesRoute()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Delete, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/organizations/org_1/series-group/A", request.RequestUri.PathAndQuery);
+                return Task.FromResult(JsonResponse("{\"name\":\"A\"}"));
+            });
+
+            var wrapper = new OrganizationWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.DeleteSeriesAsync("org_1", "A");
+
+            Assert.Equal("A", result.Name);
+        }
+
+        [Fact]
+        public async Task RetentionListAsync_UsesRetentionsRoute()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/retentions?page=2", request.RequestUri.PathAndQuery);
+                return Task.FromResult(JsonResponse("{\"data\":[]}"));
+            });
+
+            var wrapper = new RetentionWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.ListAsync(new Dictionary<string, object> { ["page"] = 2 });
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.Data);
+        }
+
+        [Fact]
+        public async Task ErrorMapping_UsesStatusFromString()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("{\"message\":\"bad request\",\"status\":\"400\"}", Encoding.UTF8, "application/json")
+                });
+            });
+
+            var wrapper = new CustomerWrapper("test_key", "v2", CreateHttpClient(handler));
+            var exception = await Assert.ThrowsAsync<FacturapiException>(() => wrapper.ListAsync());
+
+            Assert.Equal(400, exception.Status);
+            Assert.Equal("bad request", exception.Message);
+        }
+
+        [Fact]
+        public async Task ErrorMapping_UsesStatusFromFloat()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("{\"message\":\"unauthorized\",\"status\":401.0}", Encoding.UTF8, "application/json")
+                });
+            });
+
+            var wrapper = new CustomerWrapper("test_key", "v2", CreateHttpClient(handler));
+            var exception = await Assert.ThrowsAsync<FacturapiException>(() => wrapper.ListAsync());
+
+            Assert.Equal(401, exception.Status);
+            Assert.Equal("unauthorized", exception.Message);
+        }
+
+        [Fact]
+        public async Task ErrorMapping_NonJsonFallbacksToHttpStatus()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                {
+                    Content = new StringContent("server exploded", Encoding.UTF8, "text/plain")
+                });
+            });
+
+            var wrapper = new CustomerWrapper("test_key", "v2", CreateHttpClient(handler));
+            var exception = await Assert.ThrowsAsync<FacturapiException>(() => wrapper.ListAsync());
+
+            Assert.Equal(500, exception.Status);
+            Assert.Equal("An error occurred", exception.Message);
+        }
+
+        [Fact]
+        public async Task CustomerListAsync_RespectsCancellationToken()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                return Task.FromResult(JsonResponse("{\"data\":[]}"));
+            });
+
+            var wrapper = new CustomerWrapper("test_key", "v2", CreateHttpClient(handler));
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wrapper.ListAsync(cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task InvoiceDownloadPdfAsync_ReturnsSeekableStreamAtPositionZero()
+        {
+            var payload = Encoding.UTF8.GetBytes("pdf-bytes");
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/invoices/inv_1/pdf", request.RequestUri.PathAndQuery);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(payload)
+                });
+            });
+
+            var wrapper = new InvoiceWrapper("test_key", "v2", CreateHttpClient(handler));
+            using var stream = await wrapper.DownloadPdfAsync("inv_1");
+
+            Assert.Equal(0, stream.Position);
+            using var reader = new StreamReader(stream, Encoding.UTF8, false, 1024, leaveOpen: true);
+            var text = await reader.ReadToEndAsync();
+            Assert.Equal("pdf-bytes", text);
+        }
+
+        [Fact]
+        public async Task RetentionDownloadZipAsync_ReturnsSeekableStreamAtPositionZero()
+        {
+            var payload = Encoding.UTF8.GetBytes("zip-content");
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/retentions/ret_1/zip", request.RequestUri.PathAndQuery);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(payload)
+                });
+            });
+
+            var wrapper = new RetentionWrapper("test_key", "v2", CreateHttpClient(handler));
+            using var stream = await wrapper.DownloadZipAsync("ret_1");
+
+            Assert.Equal(0, stream.Position);
+            using var reader = new StreamReader(stream, Encoding.UTF8, false, 1024, leaveOpen: true);
+            var text = await reader.ReadToEndAsync();
+            Assert.Equal("zip-content", text);
+        }
+
+        private static HttpClient CreateHttpClient(HttpMessageHandler handler)
+        {
+            return new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://www.facturapi.io/v2/")
+            };
+        }
+
+        private static HttpResponseMessage JsonResponse(string json)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder;
+
+            public RecordingHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            {
+                this.responder = responder;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return this.responder(request, cancellationToken);
+            }
+        }
+    }
+}

--- a/IFacturapiClient.cs
+++ b/IFacturapiClient.cs
@@ -5,15 +5,15 @@ namespace Facturapi
 {
     public interface IFacturapiClient : IDisposable
     {
-        CustomerWrapper Customer { get; }
-        ProductWrapper Product { get; }
-        InvoiceWrapper Invoice { get; }
-        OrganizationWrapper Organization { get; }
-        ReceiptWrapper Receipt { get; }
-        RetentionWrapper Retention { get; }
-        CatalogWrapper Catalog { get; }
-        CartaporteCatalogWrapper CartaporteCatalog { get; }
-        ToolWrapper Tool { get; }
-        WebhookWrapper Webhook { get; }
+        ICustomerWrapper Customer { get; }
+        IProductWrapper Product { get; }
+        IInvoiceWrapper Invoice { get; }
+        IOrganizationWrapper Organization { get; }
+        IReceiptWrapper Receipt { get; }
+        IRetentionWrapper Retention { get; }
+        ICatalogWrapper Catalog { get; }
+        ICartaporteCatalogWrapper CartaporteCatalog { get; }
+        IToolWrapper Tool { get; }
+        IWebhookWrapper Webhook { get; }
     }
 }

--- a/Models/OrganizationInvite.cs
+++ b/Models/OrganizationInvite.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace Facturapi
+{
+    public class OrganizationInvite
+    {
+        public string Id { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public string Email { get; set; }
+        public string OrganizationName { get; set; }
+        public string Role { get; set; }
+        public string RoleName { get; set; }
+        public List<string> Roles { get; set; }
+        public DateTime? ExpiresAt { get; set; }
+    }
+}

--- a/Models/OrganizationTeamRole.cs
+++ b/Models/OrganizationTeamRole.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace Facturapi
+{
+    public class OrganizationTeamRole
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string TemplateCode { get; set; }
+        public string Scope { get; set; }
+        public string Organization { get; set; }
+        public List<string> Operations { get; set; }
+        public int UsedBy { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public Dictionary<string, object> CreatedBy { get; set; }
+        public Dictionary<string, object> UpdatedBy { get; set; }
+    }
+}

--- a/Models/OrganizationTeamRoleTemplate.cs
+++ b/Models/OrganizationTeamRoleTemplate.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Facturapi
+{
+    public class OrganizationTeamRoleTemplate
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public List<string> Operations { get; set; }
+    }
+}

--- a/Models/OrganizationUserAccess.cs
+++ b/Models/OrganizationUserAccess.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace Facturapi
+{
+    public class OrganizationUserAccess
+    {
+        public string Id { get; set; }
+        public string FullName { get; set; }
+        public string Email { get; set; }
+        public string Role { get; set; }
+        public string RoleName { get; set; }
+        public string Organization { get; set; }
+        public List<string> Operations { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+    }
+}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FacturapiTest")]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Facturapi .NET Library
 
 [![NuGet version](https://badge.fury.io/nu/Facturapi.svg)](https://www.nuget.org/packages/Facturapi/)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Facturapi.svg)](https://www.nuget.org/packages/Facturapi/)
+[![CI](https://github.com/FacturAPI/facturapi-net/actions/workflows/ci.yml/badge.svg)](https://github.com/FacturAPI/facturapi-net/actions/workflows/ci.yml)
 
 Librería oficial para .NET de https://www.facturapi.io
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,34 @@ Facturapi ayuda a generar facturas electrónicas válidas en México (CFDI) de l
 
 Si alguna vez has usado [Stripe](https://stripe.com) o [Conekta](https://conekta.io), verás que Facturapi es igual de sencillo de entender e integrar a tu aplicación.
 
+## Migración a v6
+
+### ¿Cuándo NO necesitas cambiar nada?
+
+No necesitas actualizar tu código si:
+- Creas `FacturapiClient` y llamas métodos directamente (por ejemplo `await client.Invoice.CreateAsync(...)`).
+- Usas `var` al guardar wrappers (por ejemplo `var invoices = client.Invoice;`).
+- No dependes de tipos concretos de wrappers en firmas, propiedades o pruebas.
+
+### ¿Cuándo SÍ necesitas actualizar?
+
+Debes ajustar tu código si:
+- Declaras wrappers como clases concretas (`CustomerWrapper`, `InvoiceWrapper`, etc.).
+- Mockeas wrappers concretos en pruebas.
+- Expones wrappers concretos en tus propias interfaces o APIs públicas.
+
+Antes (v5):
+
+```csharp
+CustomerWrapper customers = client.Customer;
+```
+
+Después (v6):
+
+```csharp
+ICustomerWrapper customers = client.Customer;
+```
+
 ## Instalación
 
 Puedes instalar Facturapi en tu proyecto usando [Nuget](https://www.nuget.org/)
@@ -30,9 +58,22 @@ Empieza por crear una instancia del Wrapper de Facturapi usando tu llave secreta
 using Facturapi;
 
 // Esto asegura que puedas usar diferentes ApiKeys en diferentes instancias de Wrapper
-var facturapi = new FacturapiClient('TU_API_KEY');
+var facturapi = new FacturapiClient("TU_API_KEY");
 // Después, procede a llamar a los métodos como muestra la documentación.
-var invoice = await facturapi.Invoice.Create(...);
+var invoice = await facturapi.Invoice.CreateAsync(...);
+```
+
+### Escenario avanzado: usar tu propio `HttpClient`
+
+Para la mayoría de usuarios, usa el constructor normal de `FacturapiClient`.
+Si necesitas un `HttpClient` custom (por ejemplo para un `HttpMessageHandler` propio), usa el factory avanzado:
+
+```csharp
+using System.Net.Http;
+using Facturapi;
+
+var customHttpClient = new HttpClient();
+var facturapi = FacturapiClient.CreateWithCustomHttpClient("TU_API_KEY", customHttpClient);
 ```
 
 ### Métodos asíncronos (async, await)
@@ -41,10 +82,10 @@ Esta librería utiliza métodos asíncronos. Si tu aplicación no tiene código 
 
 ```csharp
 // Asíncrono
-var customers = await facturapi.Customer.List();
+var customers = await facturapi.Customer.ListAsync();
 
 // Síncrono
-var customers = facturapi.Customer.List().GetAwaiter().GetResult();
+var customers = facturapi.Customer.ListAsync().GetAwaiter().GetResult();
 ```
 
 ## Uso de la librería
@@ -104,7 +145,7 @@ var product = await facturapi.Product.CreateAsync(new Dictionary<string, object>
 ### Crear una factura
 
 ```csharp
-var invoice = await facturapi.Product.CreateAsync(new Dictionary<string, object>
+var invoice = await facturapi.Invoice.CreateAsync(new Dictionary<string, object>
 {
   ["customer"] = "ID_DEL_CLIENTE",	  // Para clientes no registrados, puedes asignar
 									  // un Dictionary con los datos del cliente.
@@ -116,7 +157,7 @@ var invoice = await facturapi.Product.CreateAsync(new Dictionary<string, object>
       ["product"] = "ID_DEL_PRODUCTO" // Para productos no registrados, puedes asignar
                                       // un Dictionary con los datos del producto.
     }
-  }
+  },
   ["payment_form"] = Facturapi.PaymentForm.DINERO_ELECTRONICO
 });
 ```
@@ -131,9 +172,8 @@ var zipStream = await facturapi.Invoice.DownloadZipAsync(invoice.Id);
 var xmlStream = await facturapi.Invoice.DownloadXmlAsync(invoice.Id);
 var pdfStream = await facturapi.Invoice.DownloadPdfAsync(invoice.Id);
 // Y luego guardarlo en un archivo del disco duro
-var file = new System.IO.FileStrem("C:\\route\\to\\save\\invoice.zip", FileMode.Create);
-zipStream.CopyTo(file);
-file.Close();
+using var file = new System.IO.FileStream("C:\\route\\to\\save\\invoice.zip", System.IO.FileMode.Create);
+await zipStream.CopyToAsync(file);
 ```
 
 #### Envía la factura por correo electrónico

--- a/Router/OrganizationRouter.cs
+++ b/Router/OrganizationRouter.cs
@@ -120,5 +120,60 @@ namespace Facturapi
         {
             return $"{RetrieveOrganization(organizationId)}/domain";
         }
+
+        public static string ListTeamAccess(string organizationId)
+        {
+            return $"{RetrieveOrganization(organizationId)}/team";
+        }
+
+        public static string RetrieveTeamAccess(string organizationId, string accessId)
+        {
+            return $"{ListTeamAccess(organizationId)}/{accessId}";
+        }
+
+        public static string UpdateTeamAccessRole(string organizationId, string accessId)
+        {
+            return $"{RetrieveTeamAccess(organizationId, accessId)}/role";
+        }
+
+        public static string ListSentTeamInvites(string organizationId)
+        {
+            return $"{ListTeamAccess(organizationId)}/invites";
+        }
+
+        public static string CancelTeamInvite(string organizationId, string inviteKey)
+        {
+            return $"{ListSentTeamInvites(organizationId)}/{inviteKey}";
+        }
+
+        public static string ListReceivedTeamInvites()
+        {
+            return "organizations/invites/pending";
+        }
+
+        public static string RespondTeamInvite(string inviteKey)
+        {
+            return $"organizations/invites/{inviteKey}/response";
+        }
+
+        public static string ListTeamRoles(string organizationId)
+        {
+            return $"{ListTeamAccess(organizationId)}/roles";
+        }
+
+        public static string ListTeamRoleTemplates(string organizationId)
+        {
+            return $"{ListTeamRoles(organizationId)}/templates";
+        }
+
+        public static string ListTeamRoleOperations(string organizationId)
+        {
+            return $"{ListTeamRoles(organizationId)}/operations";
+        }
+
+        public static string RetrieveTeamRole(string organizationId, string roleId)
+        {
+            return $"{ListTeamRoles(organizationId)}/{roleId}";
+        }
     }
 }

--- a/Router/RetentionRouter.cs
+++ b/Router/RetentionRouter.cs
@@ -8,7 +8,7 @@ namespace Facturapi
 {
     internal static partial class Router
     {
-        public static string ListRetentionss(Dictionary<string, object> query = null)
+        public static string ListRetentions(Dictionary<string, object> query = null)
         {
             return UriWithQuery("retentions", query);
         }

--- a/Router/Router.cs
+++ b/Router/Router.cs
@@ -8,20 +8,30 @@ namespace Facturapi
     {
         private static string UriWithQuery(string path, Dictionary<string, object> query = null)
         {
-            var url = path;
-            if (query != null)
-            {
-                return $"{path}?{DictionaryToQueryString(query)}";
-            }
-            else
+            if (query == null || query.Count == 0)
             {
                 return path;
             }
+
+            var queryString = DictionaryToQueryString(query);
+            if (String.IsNullOrEmpty(queryString))
+            {
+                return path;
+            }
+
+            return $"{path}?{queryString}";
         }
 
         private static string DictionaryToQueryString(Dictionary<string, object> dict)
         {
-            return String.Join("&", dict.Select(x => String.Format("{0}={1}", Uri.EscapeDataString(x.Key), Uri.EscapeDataString(x.Value.ToString()))));
+            return String.Join(
+                "&",
+                dict
+                    .Where(x => !String.IsNullOrEmpty(x.Key))
+                    .Select(x => String.Format(
+                        "{0}={1}",
+                        Uri.EscapeDataString(x.Key),
+                        Uri.EscapeDataString(x.Value?.ToString() ?? String.Empty))));
         }
     }
 }

--- a/Wrappers/BaseWrapper.cs
+++ b/Wrappers/BaseWrapper.cs
@@ -79,7 +79,7 @@ namespace Facturapi.Wrappers
                 return;
             }
 
-            var resultString = await response.Content.ReadAsStringAsync();
+            var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             throw CreateException(resultString, response);
         }
     }

--- a/Wrappers/CartaporteCatalogWrapper.cs
+++ b/Wrappers/CartaporteCatalogWrapper.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class CartaporteCatalogWrapper : BaseWrapper
+    public class CartaporteCatalogWrapper : BaseWrapper, ICartaporteCatalogWrapper
     {
         internal CartaporteCatalogWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -14,60 +14,60 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<CatalogItem>> SearchAirTransportCodes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteAirTransportCodes(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteAirTransportCodes(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchTransportConfigs(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteTransportConfigs(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteTransportConfigs(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchRightsOfPassage(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteRightsOfPassage(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteRightsOfPassage(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchCustomsDocuments(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteCustomsDocuments(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteCustomsDocuments(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchPackagingTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaportePackagingTypes(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaportePackagingTypes(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchTrailerTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteTrailerTypes(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteTrailerTypes(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchHazardousMaterials(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteHazardousMaterials(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteHazardousMaterials(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchNavalAuthorizations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteNavalAuthorizations(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteNavalAuthorizations(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchPortStations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaportePortStations(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaportePortStations(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchMarineContainers(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchCartaporteMarineContainers(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchCartaporteMarineContainers(query), cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url, CancellationToken cancellationToken)
         {
             using (var response = await client.GetAsync(url, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<CatalogItem>>(resultString, this.jsonSettings);
                 return searchResult;
             }

--- a/Wrappers/CartaporteCatalogWrapper.cs
+++ b/Wrappers/CartaporteCatalogWrapper.cs
@@ -64,7 +64,7 @@ namespace Facturapi.Wrappers
 
         private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(url, cancellationToken))
+            using (var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Wrappers/CatalogWrapper.cs
+++ b/Wrappers/CatalogWrapper.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class CatalogWrapper : BaseWrapper
+    public class CatalogWrapper : BaseWrapper, ICatalogWrapper
     {
         internal CatalogWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -14,20 +14,20 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<CatalogItem>> SearchProducts(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchProductKeys(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchProductKeys(query), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SearchResult<CatalogItem>> SearchUnits(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            return await this.SearchCatalogAsync(Router.SearchUnitKeys(query), cancellationToken);
+            return await this.SearchCatalogAsync(Router.SearchUnitKeys(query), cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url, CancellationToken cancellationToken)
         {
             using (var response = await client.GetAsync(url, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<CatalogItem>>(resultString, this.jsonSettings);
                 return searchResult;
             }

--- a/Wrappers/CatalogWrapper.cs
+++ b/Wrappers/CatalogWrapper.cs
@@ -24,7 +24,7 @@ namespace Facturapi.Wrappers
 
         private async Task<SearchResult<CatalogItem>> SearchCatalogAsync(string url, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(url, cancellationToken))
+            using (var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Wrappers/CustomerWrapper.cs
+++ b/Wrappers/CustomerWrapper.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class CustomerWrapper : BaseWrapper
+    public class CustomerWrapper : BaseWrapper, ICustomerWrapper
     {
         internal CustomerWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -17,8 +17,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListCustomers(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Customer>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -30,8 +30,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateCustomer(queryParams), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -41,8 +41,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.RetrieveCustomer(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -52,8 +52,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.DeleteCustomer(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -64,8 +64,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateCustomer(id, queryParams), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Customer>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -75,8 +75,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ValidateCustomerTaxInfo(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var validation = JsonConvert.DeserializeObject<TaxInfoValidation>(resultString, this.jsonSettings);
                 return validation;
             }
@@ -87,7 +87,7 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.SendEditLinkByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/Wrappers/CustomerWrapper.cs
+++ b/Wrappers/CustomerWrapper.cs
@@ -15,7 +15,7 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Customer>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListCustomers(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListCustomers(query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -28,7 +28,7 @@ namespace Facturapi.Wrappers
         public async Task<Customer> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> queryParams = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateCustomer(queryParams), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateCustomer(queryParams), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -39,7 +39,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Customer> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveCustomer(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.RetrieveCustomer(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -50,7 +50,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Customer> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteCustomer(id), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.DeleteCustomer(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -62,7 +62,7 @@ namespace Facturapi.Wrappers
         public async Task<Customer> UpdateAsync(string id, Dictionary<string, object> data, Dictionary<string, object> queryParams = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateCustomer(id, queryParams), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateCustomer(id, queryParams), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -73,7 +73,7 @@ namespace Facturapi.Wrappers
 
         public async Task<TaxInfoValidation> ValidateTaxInfoAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ValidateCustomerTaxInfo(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.ValidateCustomerTaxInfo(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -85,7 +85,7 @@ namespace Facturapi.Wrappers
         public async Task SendEditLinkByEmailAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendEditLinkByEmail(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.SendEditLinkByEmail(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }

--- a/Wrappers/ICartaporteCatalogWrapper.cs
+++ b/Wrappers/ICartaporteCatalogWrapper.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface ICartaporteCatalogWrapper
+    {
+        Task<SearchResult<CatalogItem>> SearchAirTransportCodes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchTransportConfigs(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchRightsOfPassage(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchCustomsDocuments(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchPackagingTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchTrailerTypes(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchHazardousMaterials(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchNavalAuthorizations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchPortStations(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchMarineContainers(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/ICatalogWrapper.cs
+++ b/Wrappers/ICatalogWrapper.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface ICatalogWrapper
+    {
+        Task<SearchResult<CatalogItem>> SearchProducts(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<SearchResult<CatalogItem>> SearchUnits(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/ICustomerWrapper.cs
+++ b/Wrappers/ICustomerWrapper.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface ICustomerWrapper
+    {
+        Task<SearchResult<Customer>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<Customer> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> queryParams = null, CancellationToken cancellationToken = default);
+        Task<Customer> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<Customer> DeleteAsync(string id, CancellationToken cancellationToken = default);
+        Task<Customer> UpdateAsync(string id, Dictionary<string, object> data, Dictionary<string, object> queryParams = null, CancellationToken cancellationToken = default);
+        Task<TaxInfoValidation> ValidateTaxInfoAsync(string id, CancellationToken cancellationToken = default);
+        Task SendEditLinkByEmailAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/IInvoiceWrapper.cs
+++ b/Wrappers/IInvoiceWrapper.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface IInvoiceWrapper
+    {
+        Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<Invoice> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
+        Task<Invoice> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadZipAsync(string id, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadPdfAsync(string id, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadXmlAsync(string id, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadCancellationReceiptXmlAsync(string id, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadCancellationReceiptPdfAsync(string id, CancellationToken cancellationToken = default);
+        Task<Invoice> UpdateStatusAsync(string id, CancellationToken cancellationToken = default);
+        Task<Invoice> UpdateDraftAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Invoice> StampDraftAsync(string id, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
+        [Obsolete("Use StampDraftAsync instead.")]
+        Task<Invoice> StampDraft(string id, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
+        Task<Invoice> CopyToDraftAsync(string id, CancellationToken cancellationToken = default);
+        Task<Stream> PreviewPdfAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/IOrganizationWrapper.cs
+++ b/Wrappers/IOrganizationWrapper.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface IOrganizationWrapper
+    {
+        Task<SearchResult<Organization>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<Organization> MeAsync(CancellationToken cancellationToken = default);
+        Task<DomainAvailability> CheckDomainIsAvailableAsync(string domain, CancellationToken cancellationToken = default);
+        Task<Organization> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Organization> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<Organization> DeleteAsync(string id, CancellationToken cancellationToken = default);
+        Task<Organization> UploadLogoAsync(string id, Stream file, CancellationToken cancellationToken = default);
+        Task<Organization> UploadCertificateAsync(string id, Stream cerFile, Stream keyFile, string password, CancellationToken cancellationToken = default);
+        Task<Certificate> DeleteCertificateAsync(string id, CancellationToken cancellationToken = default);
+        Task<Organization> UpdateLegalAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Organization> UpdateReceiptSettingsAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Organization> UpdateCustomizationAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Organization> UpdateDomainAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<string> GetTestApiKeyAsync(string id, CancellationToken cancellationToken = default);
+        Task<string> RenewTestApiKeyAsync(string id, CancellationToken cancellationToken = default);
+        Task<LiveApiKey> ListLiveApiKeysAsync(string id, CancellationToken cancellationToken = default);
+        Task<string> RenewLiveApiKeyAsync(string id, CancellationToken cancellationToken = default);
+        Task<List<SeriesGroup>> ListSeriesAsync(string id, CancellationToken cancellationToken = default);
+        Task<SeriesGroup> CreateSeriesAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<SeriesGroup> UpdateSeriesAsync(string id, string seriesName, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<SeriesGroup> DeleteSeriesAsync(string id, string seriesName, CancellationToken cancellationToken = default);
+        Task<List<LiveApiKey>> DeleteLiveApiKeyAsync(string id, string apiKeyId, CancellationToken cancellationToken = default);
+        Task<Organization> UpdateSelfInvoiceSettingsAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/IOrganizationWrapper.cs
+++ b/Wrappers/IOrganizationWrapper.cs
@@ -30,5 +30,21 @@ namespace Facturapi.Wrappers
         Task<SeriesGroup> DeleteSeriesAsync(string id, string seriesName, CancellationToken cancellationToken = default);
         Task<List<LiveApiKey>> DeleteLiveApiKeyAsync(string id, string apiKeyId, CancellationToken cancellationToken = default);
         Task<Organization> UpdateSelfInvoiceSettingsAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<List<OrganizationUserAccess>> ListTeamAccessAsync(string organizationId, CancellationToken cancellationToken = default);
+        Task<OrganizationUserAccess> RetrieveTeamAccessAsync(string organizationId, string accessId, CancellationToken cancellationToken = default);
+        Task<OrganizationUserAccess> UpdateTeamAccessRoleAsync(string organizationId, string accessId, string role, CancellationToken cancellationToken = default);
+        Task<bool> RemoveTeamAccessAsync(string organizationId, string accessId, CancellationToken cancellationToken = default);
+        Task<List<OrganizationInvite>> ListSentTeamInvitesAsync(string organizationId, CancellationToken cancellationToken = default);
+        Task<OrganizationInvite> InviteUserToTeamAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<bool> CancelTeamInviteAsync(string organizationId, string inviteKey, CancellationToken cancellationToken = default);
+        Task<List<OrganizationInvite>> ListReceivedTeamInvitesAsync(CancellationToken cancellationToken = default);
+        Task<bool> RespondTeamInviteAsync(string inviteKey, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<List<OrganizationTeamRole>> ListTeamRolesAsync(string organizationId, CancellationToken cancellationToken = default);
+        Task<List<OrganizationTeamRoleTemplate>> ListTeamRoleTemplatesAsync(string organizationId, CancellationToken cancellationToken = default);
+        Task<List<string>> ListTeamRoleOperationsAsync(string organizationId, CancellationToken cancellationToken = default);
+        Task<OrganizationTeamRole> RetrieveTeamRoleAsync(string organizationId, string roleId, CancellationToken cancellationToken = default);
+        Task<OrganizationTeamRole> CreateTeamRoleAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<OrganizationTeamRole> UpdateTeamRoleAsync(string organizationId, string roleId, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<bool> DeleteTeamRoleAsync(string organizationId, string roleId, CancellationToken cancellationToken = default);
     }
 }

--- a/Wrappers/IProductWrapper.cs
+++ b/Wrappers/IProductWrapper.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface IProductWrapper
+    {
+        Task<SearchResult<Product>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<Product> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Product> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<Product> DeleteAsync(string id, CancellationToken cancellationToken = default);
+        Task<Product> UpdateAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/IReceiptWrapper.cs
+++ b/Wrappers/IReceiptWrapper.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface IReceiptWrapper
+    {
+        Task<SearchResult<Receipt>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<Receipt> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Receipt> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<Receipt> CancelAsync(string id, CancellationToken cancellationToken = default);
+        Task InvoiceAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task CreateGlobalInvoiceAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadPdfAsync(string id, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/IRetentionWrapper.cs
+++ b/Wrappers/IRetentionWrapper.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface IRetentionWrapper
+    {
+        Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<Invoice> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Invoice> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadZipAsync(string id, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadPdfAsync(string id, CancellationToken cancellationToken = default);
+        Task<Stream> DownloadXmlAsync(string id, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/IToolWrapper.cs
+++ b/Wrappers/IToolWrapper.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface IToolWrapper
+    {
+        Task<TaxIdValidation> ValidateTaxIdAsync(string taxId, CancellationToken cancellationToken = default);
+        Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/IWebhookWrapper.cs
+++ b/Wrappers/IWebhookWrapper.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Facturapi.Wrappers
+{
+    public interface IWebhookWrapper
+    {
+        Task<SearchResult<Webhook>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
+        Task<Webhook> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Webhook> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<Webhook> UpdateAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default);
+        Task<Webhook> DeleteAsync(string id, CancellationToken cancellationToken = default);
+        Task<Webhook> ValidateSignatureAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default);
+    }
+}

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -17,7 +17,7 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListInvoices(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListInvoices(query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -30,7 +30,7 @@ namespace Facturapi.Wrappers
         public async Task<Invoice> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> options = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateInvoice(options), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateInvoice(options), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -41,7 +41,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Invoice> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveInvoice(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.RetrieveInvoice(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -52,7 +52,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.CancelInvoice(id, query), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.CancelInvoice(id, query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -64,7 +64,7 @@ namespace Facturapi.Wrappers
         public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendByEmail(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.SendByEmail(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
@@ -72,7 +72,7 @@ namespace Facturapi.Wrappers
 
         private async Task<Stream> DownloadAsync(string id, string format, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(Router.DownloadInvoice(id, format), cancellationToken))
+            using (var response = await client.GetAsync(Router.DownloadInvoice(id, format), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -100,7 +100,7 @@ namespace Facturapi.Wrappers
 
         private async Task<Stream> DownloadCancellationReceiptAsync(string id, string format, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(Router.DownloadCancellationReceipt(id, format), cancellationToken))
+            using (var response = await client.GetAsync(Router.DownloadCancellationReceipt(id, format), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -124,7 +124,7 @@ namespace Facturapi.Wrappers
         public async Task<Invoice> UpdateStatusAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateStatus(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateStatus(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -136,7 +136,7 @@ namespace Facturapi.Wrappers
         public async Task<Invoice> UpdateDraftAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateDraftInvoice(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateDraftInvoice(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -148,7 +148,7 @@ namespace Facturapi.Wrappers
         public async Task<Invoice> StampDraftAsync(string id, Dictionary<string, object> options = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.StampDraftInvoice(id, options), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.StampDraftInvoice(id, options), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -166,7 +166,7 @@ namespace Facturapi.Wrappers
         public async Task<Invoice> CopyToDraftAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CopyInvoice(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CopyInvoice(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -178,7 +178,7 @@ namespace Facturapi.Wrappers
         public async Task<Stream> PreviewPdfAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.PreviewPdf(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.PreviewPdf(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -8,7 +9,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class InvoiceWrapper : BaseWrapper
+    public class InvoiceWrapper : BaseWrapper, IInvoiceWrapper
     {
         internal InvoiceWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -18,8 +19,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListInvoices(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -31,8 +32,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateInvoice(options), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
@@ -42,8 +43,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.RetrieveInvoice(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
@@ -53,8 +54,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.CancelInvoice(id, query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
@@ -65,7 +66,7 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.SendByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -73,10 +74,10 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.DownloadInvoice(id, format), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken).ConfigureAwait(false);
                 memory.Position = 0;
                 return memory;
             }
@@ -101,10 +102,10 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.DownloadCancellationReceipt(id, format), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken).ConfigureAwait(false);
                 memory.Position = 0;
                 return memory;
             }
@@ -125,8 +126,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateStatus(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
@@ -137,23 +138,29 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateDraftInvoice(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
         }
 
-        public async Task<Invoice> StampDraft(string id, Dictionary<string, object> options = null, CancellationToken cancellationToken = default)
+        public async Task<Invoice> StampDraftAsync(string id, Dictionary<string, object> options = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.StampDraftInvoice(id, options), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
+        }
+
+        [Obsolete("Use StampDraftAsync instead.")]
+        public Task<Invoice> StampDraft(string id, Dictionary<string, object> options = null, CancellationToken cancellationToken = default)
+        {
+            return this.StampDraftAsync(id, options, cancellationToken);
         }
 
         public async Task<Invoice> CopyToDraftAsync(string id, CancellationToken cancellationToken = default)
@@ -161,8 +168,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent("", Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CopyInvoice(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
             }
@@ -173,10 +180,10 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.PreviewPdf(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken).ConfigureAwait(false);
                 memory.Position = 0;
                 return memory;
             }

--- a/Wrappers/OrganizationWrapper.cs
+++ b/Wrappers/OrganizationWrapper.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class OrganizationWrapper : BaseWrapper
+    public class OrganizationWrapper : BaseWrapper, IOrganizationWrapper
     {
         internal OrganizationWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -18,8 +18,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListOrganizations(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Organization>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -30,8 +30,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.OrganizationMe(), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -41,8 +41,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.CheckDomainAvailability(new Dictionary<string, object> { ["domain"] = domain }), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var availability = JsonConvert.DeserializeObject<DomainAvailability>(resultString, this.jsonSettings);
                 return availability;
             }
@@ -53,8 +53,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateOrganization(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -64,8 +64,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.RetrieveOrganization(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -75,8 +75,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.DeleteOrganization(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -89,8 +89,8 @@ namespace Facturapi.Wrappers
                 form.Add(new StreamContent(file), "file", "logo.jpg");
                 using (var response = await client.PutAsync(Router.UploadLogo(id), form, cancellationToken))
                 {
-                    await this.ThrowIfErrorAsync(response, cancellationToken);
-                    var resultString = await response.Content.ReadAsStringAsync();
+                    await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                    var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                     return organization;
                 }
@@ -106,8 +106,8 @@ namespace Facturapi.Wrappers
                 form.Add(new StringContent(password), "password");
                 using (var response = await client.PutAsync(Router.UploadCertificate(id), form, cancellationToken))
                 {
-                    await this.ThrowIfErrorAsync(response, cancellationToken);
-                    var resultString = await response.Content.ReadAsStringAsync();
+                    await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                    var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                     return organization;
                 }
@@ -118,8 +118,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.DeleteCertificate(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var certificateInfo = JsonConvert.DeserializeObject<Certificate>(resultString, this.jsonSettings);
                 return certificateInfo;
             }
@@ -130,8 +130,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateLegal(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -142,8 +142,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateReceipts(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -154,8 +154,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateCustomization(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -166,8 +166,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateDomain(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }
@@ -177,8 +177,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.GetTestApiKey(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return resultString;
             }
         }
@@ -189,8 +189,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(""))
             using (var response = await client.PutAsync(Router.RenewTestApiKey(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return resultString;
             }
         }
@@ -199,8 +199,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListAsyncLiveApiKeys(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var listResult = JsonConvert.DeserializeObject<LiveApiKey>(resultString, this.jsonSettings);
 
                 return listResult;
@@ -212,8 +212,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(""))
             using (var response = await client.PutAsync(Router.RenewLiveApiKey(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return resultString;
             }
         }
@@ -223,8 +223,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListSeriesGroup(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<List<SeriesGroup>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -236,8 +236,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateSeriesGroup(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
                 return series;
             }
@@ -248,8 +248,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
                 return series;
             }
@@ -259,8 +259,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.UpdateSeriesGroup(id, seriesName), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var series = JsonConvert.DeserializeObject<SeriesGroup>(resultString, this.jsonSettings);
                 return series;
             }
@@ -270,8 +270,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.DeleteLiveApiKey(id, apiKeyId), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var deserializeJson = JsonConvert.DeserializeObject<List<LiveApiKey>>(resultString, this.jsonSettings);
                 return deserializeJson;
             }
@@ -282,8 +282,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateSelfInvoiceSettings(organizationId), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var organization = JsonConvert.DeserializeObject<Organization>(resultString, this.jsonSettings);
                 return organization;
             }

--- a/Wrappers/OrganizationWrapper.cs
+++ b/Wrappers/OrganizationWrapper.cs
@@ -16,7 +16,7 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Organization>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListOrganizations(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListOrganizations(query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -28,7 +28,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Organization> MeAsync(CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.OrganizationMe(), cancellationToken))
+            using (var response = await client.GetAsync(Router.OrganizationMe(), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -39,7 +39,7 @@ namespace Facturapi.Wrappers
 
         public async Task<DomainAvailability> CheckDomainIsAvailableAsync(string domain, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.CheckDomainAvailability(new Dictionary<string, object> { ["domain"] = domain }), cancellationToken))
+            using (var response = await client.GetAsync(Router.CheckDomainAvailability(new Dictionary<string, object> { ["domain"] = domain }), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Facturapi.Wrappers
         public async Task<Organization> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateOrganization(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateOrganization(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -62,7 +62,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Organization> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveOrganization(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.RetrieveOrganization(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -73,7 +73,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Organization> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteOrganization(id), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.DeleteOrganization(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -87,7 +87,7 @@ namespace Facturapi.Wrappers
             using (var form = new MultipartFormDataContent())
             {
                 form.Add(new StreamContent(file), "file", "logo.jpg");
-                using (var response = await client.PutAsync(Router.UploadLogo(id), form, cancellationToken))
+                using (var response = await client.PutAsync(Router.UploadLogo(id), form, cancellationToken).ConfigureAwait(false))
                 {
                     await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                     var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -104,7 +104,7 @@ namespace Facturapi.Wrappers
                 form.Add(new StreamContent(cerFile), "cer", "certificate.cer");
                 form.Add(new StreamContent(keyFile), "key", "key.key");
                 form.Add(new StringContent(password), "password");
-                using (var response = await client.PutAsync(Router.UploadCertificate(id), form, cancellationToken))
+                using (var response = await client.PutAsync(Router.UploadCertificate(id), form, cancellationToken).ConfigureAwait(false))
                 {
                     await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                     var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -116,7 +116,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Certificate> DeleteCertificateAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteCertificate(id), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.DeleteCertificate(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -128,7 +128,7 @@ namespace Facturapi.Wrappers
         public async Task<Organization> UpdateLegalAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateLegal(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateLegal(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -140,7 +140,7 @@ namespace Facturapi.Wrappers
         public async Task<Organization> UpdateReceiptSettingsAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateReceipts(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateReceipts(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -152,7 +152,7 @@ namespace Facturapi.Wrappers
         public async Task<Organization> UpdateCustomizationAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateCustomization(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateCustomization(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -164,7 +164,7 @@ namespace Facturapi.Wrappers
         public async Task<Organization> UpdateDomainAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateDomain(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateDomain(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -175,7 +175,7 @@ namespace Facturapi.Wrappers
 
         public async Task<string> GetTestApiKeyAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.GetTestApiKey(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.GetTestApiKey(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -187,7 +187,7 @@ namespace Facturapi.Wrappers
         public async Task<string> RenewTestApiKeyAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(""))
-            using (var response = await client.PutAsync(Router.RenewTestApiKey(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.RenewTestApiKey(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -197,7 +197,7 @@ namespace Facturapi.Wrappers
 
         public async Task<LiveApiKey> ListLiveApiKeysAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListAsyncLiveApiKeys(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListAsyncLiveApiKeys(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -210,7 +210,7 @@ namespace Facturapi.Wrappers
         public async Task<string> RenewLiveApiKeyAsync(string id, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(""))
-            using (var response = await client.PutAsync(Router.RenewLiveApiKey(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.RenewLiveApiKey(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -221,7 +221,7 @@ namespace Facturapi.Wrappers
 
         public async Task<List<SeriesGroup>> ListSeriesAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListSeriesGroup(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListSeriesGroup(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -234,7 +234,7 @@ namespace Facturapi.Wrappers
         public async Task<SeriesGroup> CreateSeriesAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateSeriesGroup(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateSeriesGroup(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -246,7 +246,7 @@ namespace Facturapi.Wrappers
         public async Task<SeriesGroup> UpdateSeriesAsync(string id, string seriesName, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateSeriesGroup(id, seriesName), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -257,7 +257,7 @@ namespace Facturapi.Wrappers
         
         public async Task<SeriesGroup> DeleteSeriesAsync(string id, string seriesName, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.UpdateSeriesGroup(id, seriesName), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.DeleteSeriesGroup(id, seriesName), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -268,7 +268,7 @@ namespace Facturapi.Wrappers
         
         public async Task<List<LiveApiKey>> DeleteLiveApiKeyAsync(string id, string apiKeyId, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteLiveApiKey(id, apiKeyId), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.DeleteLiveApiKey(id, apiKeyId), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -280,7 +280,7 @@ namespace Facturapi.Wrappers
         public async Task<Organization> UpdateSelfInvoiceSettingsAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateSelfInvoiceSettings(organizationId), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateSelfInvoiceSettings(organizationId), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Wrappers/OrganizationWrapper.cs
+++ b/Wrappers/OrganizationWrapper.cs
@@ -288,5 +288,188 @@ namespace Facturapi.Wrappers
                 return organization;
             }
         }
+
+        public async Task<List<OrganizationUserAccess>> ListTeamAccessAsync(string organizationId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.ListTeamAccess(organizationId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<List<OrganizationUserAccess>>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<OrganizationUserAccess> RetrieveTeamAccessAsync(string organizationId, string accessId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.RetrieveTeamAccess(organizationId, accessId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<OrganizationUserAccess>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<OrganizationUserAccess> UpdateTeamAccessRoleAsync(string organizationId, string accessId, string role, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(new Dictionary<string, object> { ["role"] = role }), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.UpdateTeamAccessRole(organizationId, accessId), content, cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<OrganizationUserAccess>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<bool> RemoveTeamAccessAsync(string organizationId, string accessId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.DeleteAsync(Router.RetrieveTeamAccess(organizationId, accessId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return DeserializeOk(resultString);
+            }
+        }
+
+        public async Task<List<OrganizationInvite>> ListSentTeamInvitesAsync(string organizationId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.ListSentTeamInvites(organizationId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<List<OrganizationInvite>>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<OrganizationInvite> InviteUserToTeamAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.ListSentTeamInvites(organizationId), content, cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<OrganizationInvite>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<bool> CancelTeamInviteAsync(string organizationId, string inviteKey, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.DeleteAsync(Router.CancelTeamInvite(organizationId, inviteKey), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return DeserializeOk(resultString);
+            }
+        }
+
+        public async Task<List<OrganizationInvite>> ListReceivedTeamInvitesAsync(CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.ListReceivedTeamInvites(), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<List<OrganizationInvite>>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<bool> RespondTeamInviteAsync(string inviteKey, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.RespondTeamInvite(inviteKey), content, cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return DeserializeOk(resultString);
+            }
+        }
+
+        public async Task<List<OrganizationTeamRole>> ListTeamRolesAsync(string organizationId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.ListTeamRoles(organizationId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<List<OrganizationTeamRole>>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<List<OrganizationTeamRoleTemplate>> ListTeamRoleTemplatesAsync(string organizationId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.ListTeamRoleTemplates(organizationId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<List<OrganizationTeamRoleTemplate>>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<List<string>> ListTeamRoleOperationsAsync(string organizationId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.ListTeamRoleOperations(organizationId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<List<string>>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<OrganizationTeamRole> RetrieveTeamRoleAsync(string organizationId, string roleId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.RetrieveTeamRole(organizationId, roleId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<OrganizationTeamRole>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<OrganizationTeamRole> CreateTeamRoleAsync(string organizationId, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PostAsync(Router.ListTeamRoles(organizationId), content, cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<OrganizationTeamRole>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<OrganizationTeamRole> UpdateTeamRoleAsync(string organizationId, string roleId, Dictionary<string, object> data, CancellationToken cancellationToken = default)
+        {
+            using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
+            using (var response = await client.PutAsync(Router.RetrieveTeamRole(organizationId, roleId), content, cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JsonConvert.DeserializeObject<OrganizationTeamRole>(resultString, this.jsonSettings);
+            }
+        }
+
+        public async Task<bool> DeleteTeamRoleAsync(string organizationId, string roleId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.DeleteAsync(Router.RetrieveTeamRole(organizationId, roleId), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return DeserializeOk(resultString);
+            }
+        }
+
+        private bool DeserializeOk(string resultString)
+        {
+            var result = JsonConvert.DeserializeObject<Dictionary<string, object>>(resultString, this.jsonSettings);
+            if (result != null && result.TryGetValue("ok", out var okValue))
+            {
+                if (okValue is bool okBool)
+                {
+                    return okBool;
+                }
+                if (bool.TryParse(okValue.ToString(), out var parsed))
+                {
+                    return parsed;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/Wrappers/ProductWrapper.cs
+++ b/Wrappers/ProductWrapper.cs
@@ -15,7 +15,7 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Product>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListProducts(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListProducts(query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -28,7 +28,7 @@ namespace Facturapi.Wrappers
         public async Task<Product> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateProduct(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateProduct(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -39,7 +39,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Product> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveProduct(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.RetrieveProduct(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -50,7 +50,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Product> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteProduct(id), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.DeleteProduct(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -62,7 +62,7 @@ namespace Facturapi.Wrappers
 		public async Task<Product> UpdateAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
 		{
 			using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-			using (var response = await client.PutAsync(Router.UpdateProduct(id), content, cancellationToken))
+			using (var response = await client.PutAsync(Router.UpdateProduct(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Wrappers/ProductWrapper.cs
+++ b/Wrappers/ProductWrapper.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class ProductWrapper : BaseWrapper
+    public class ProductWrapper : BaseWrapper, IProductWrapper
     {
         internal ProductWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -17,8 +17,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListProducts(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Product>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -30,8 +30,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateProduct(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -41,8 +41,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.RetrieveProduct(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
                 return product;
             }
@@ -52,8 +52,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.DeleteProduct(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
                 return product;
             }
@@ -64,8 +64,8 @@ namespace Facturapi.Wrappers
 			using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
 			using (var response = await client.PutAsync(Router.UpdateProduct(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 			    var product = JsonConvert.DeserializeObject<Product>(resultString, this.jsonSettings);
 			    return product;
             }

--- a/Wrappers/ReceiptWrapper.cs
+++ b/Wrappers/ReceiptWrapper.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class ReceiptWrapper : BaseWrapper
+    public class ReceiptWrapper : BaseWrapper, IReceiptWrapper
     {
         internal ReceiptWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -18,8 +18,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListReceipts(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Receipt>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -31,8 +31,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateReceipt(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -42,8 +42,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.RetrieveReceipt(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -53,8 +53,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.CancelReceipt(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Receipt>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -65,7 +65,7 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.InvoiceReceipt(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -74,7 +74,7 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateGlobalInvoice(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.SendReceiptByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -91,10 +91,10 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.DownloadReceiptPdf(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken).ConfigureAwait(false);
                 memory.Position = 0;
                 return memory;
             }

--- a/Wrappers/ReceiptWrapper.cs
+++ b/Wrappers/ReceiptWrapper.cs
@@ -16,7 +16,7 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Receipt>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListReceipts(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListReceipts(query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -29,7 +29,7 @@ namespace Facturapi.Wrappers
         public async Task<Receipt> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateReceipt(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateReceipt(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -40,7 +40,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Receipt> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveReceipt(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.RetrieveReceipt(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Receipt> CancelAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.CancelReceipt(id), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.CancelReceipt(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -63,7 +63,7 @@ namespace Facturapi.Wrappers
         public async Task InvoiceAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.InvoiceReceipt(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.InvoiceReceipt(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
@@ -72,7 +72,7 @@ namespace Facturapi.Wrappers
         public async Task CreateGlobalInvoiceAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateGlobalInvoice(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateGlobalInvoice(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
@@ -81,7 +81,7 @@ namespace Facturapi.Wrappers
         public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendReceiptByEmail(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.SendReceiptByEmail(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
@@ -89,7 +89,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Stream> DownloadPdfAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.DownloadReceiptPdf(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.DownloadReceiptPdf(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/Wrappers/RetentionWrapper.cs
+++ b/Wrappers/RetentionWrapper.cs
@@ -16,7 +16,7 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListRetentions(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListRetentions(query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -29,7 +29,7 @@ namespace Facturapi.Wrappers
         public async Task<Invoice> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateRetention(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateRetention(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -40,7 +40,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Invoice> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveRetention(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.RetrieveRetention(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.CancelRetention(id, query), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.CancelRetention(id, query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -63,7 +63,7 @@ namespace Facturapi.Wrappers
         public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.SendRetentionByEmail(id), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.SendRetentionByEmail(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
@@ -71,7 +71,7 @@ namespace Facturapi.Wrappers
 
         private async Task<Stream> DownloadAsync(string id, string format, CancellationToken cancellationToken)
         {
-            using (var response = await client.GetAsync(Router.DownloadRetention(id, format), cancellationToken))
+            using (var response = await client.GetAsync(Router.DownloadRetention(id, format), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/Wrappers/RetentionWrapper.cs
+++ b/Wrappers/RetentionWrapper.cs
@@ -5,11 +5,10 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
-using Newtonsoft.Json.Linq;
 
 namespace Facturapi.Wrappers
 {
-    public class RetentionWrapper : BaseWrapper
+    public class RetentionWrapper : BaseWrapper, IRetentionWrapper
     {
         internal RetentionWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -17,10 +16,10 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListRetentionss(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListRetentions(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Invoice>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -32,8 +31,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateRetention(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return customer;
             }
@@ -43,25 +42,22 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.RetrieveRetention(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var customer = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return customer;
             }
         }
 
-        public async Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null)
+        public async Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            var url = Router.CancelRetention(id, query);
-            var response = await client.DeleteAsync(url);
-            var responseString = await response.Content.ReadAsStringAsync();
-            if (!response.IsSuccessStatusCode)
+            using (var response = await client.DeleteAsync(Router.CancelRetention(id, query), cancellationToken))
             {
-                var error = JsonConvert.DeserializeObject<JObject>(responseString, this.jsonSettings);
-                throw new FacturapiException(error["message"].ToString());
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var retention = JsonConvert.DeserializeObject<Invoice>(responseString, this.jsonSettings);
+                return retention;
             }
-            var retention = JsonConvert.DeserializeObject<Invoice>(responseString, this.jsonSettings);
-            return retention;
         }
 
         public async Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default)
@@ -69,7 +65,7 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.SendRetentionByEmail(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -77,10 +73,10 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.DownloadRetention(id, format), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var responseStream = await response.Content.ReadAsStreamAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 var memory = new MemoryStream();
-                await responseStream.CopyToAsync(memory, 81920, cancellationToken);
+                await responseStream.CopyToAsync(memory, 81920, cancellationToken).ConfigureAwait(false);
                 memory.Position = 0;
                 return memory;
             }

--- a/Wrappers/ToolWrapper.cs
+++ b/Wrappers/ToolWrapper.cs
@@ -19,7 +19,7 @@ namespace Facturapi.Wrappers
                 {
                     ["tax_id"] = taxId
                 }
-            ), cancellationToken))
+            ), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -31,7 +31,7 @@ namespace Facturapi.Wrappers
 
         public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.HealthCheck(), cancellationToken))
+            using (var response = await client.GetAsync(Router.HealthCheck(), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Wrappers/ToolWrapper.cs
+++ b/Wrappers/ToolWrapper.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class ToolWrapper : BaseWrapper
+    public class ToolWrapper : BaseWrapper, IToolWrapper
     {
         internal ToolWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -21,8 +21,8 @@ namespace Facturapi.Wrappers
                 }
             ), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var result = JsonConvert.DeserializeObject<TaxIdValidation>(resultString, this.jsonSettings);
                 return result;
@@ -33,8 +33,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.HealthCheck(), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var result = JsonConvert.DeserializeObject<Dictionary<string, object>>(resultString, this.jsonSettings);
                 if (result != null && result.TryGetValue("ok", out var okValue))
                 {

--- a/Wrappers/WebhookWrapper.cs
+++ b/Wrappers/WebhookWrapper.cs
@@ -15,7 +15,7 @@ namespace Facturapi.Wrappers
 
         public async Task<SearchResult<Webhook>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.ListWebhooks(query), cancellationToken))
+            using (var response = await client.GetAsync(Router.ListWebhooks(query), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -28,7 +28,7 @@ namespace Facturapi.Wrappers
         public async Task<Webhook> CreateAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.CreateWebhook(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.CreateWebhook(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -39,7 +39,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Webhook> RetrieveAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.GetAsync(Router.RetrieveWebhook(id), cancellationToken))
+            using (var response = await client.GetAsync(Router.RetrieveWebhook(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Facturapi.Wrappers
         public async Task<Webhook> UpdateAsync(string id, Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PutAsync(Router.UpdateWebhook(id), content, cancellationToken))
+            using (var response = await client.PutAsync(Router.UpdateWebhook(id), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -62,7 +62,7 @@ namespace Facturapi.Wrappers
 
         public async Task<Webhook> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            using (var response = await client.DeleteAsync(Router.DeleteWebhook(id), cancellationToken))
+            using (var response = await client.DeleteAsync(Router.DeleteWebhook(id), cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -74,7 +74,7 @@ namespace Facturapi.Wrappers
         public async Task<Webhook> ValidateSignatureAsync(Dictionary<string, object> data, CancellationToken cancellationToken = default)
         {
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
-            using (var response = await client.PostAsync(Router.ValidateSignature(), content, cancellationToken))
+            using (var response = await client.PostAsync(Router.ValidateSignature(), content, cancellationToken).ConfigureAwait(false))
             {
                 await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Wrappers/WebhookWrapper.cs
+++ b/Wrappers/WebhookWrapper.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace Facturapi.Wrappers
 {
-    public class WebhookWrapper : BaseWrapper
+    public class WebhookWrapper : BaseWrapper, IWebhookWrapper
     {
         internal WebhookWrapper(string apiKey, string apiVersion, HttpClient httpClient) : base(apiKey, apiVersion, httpClient)
         {
@@ -17,8 +17,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.ListWebhooks(query), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 var searchResult = JsonConvert.DeserializeObject<SearchResult<Webhook>>(resultString, this.jsonSettings);
                 return searchResult;
@@ -30,8 +30,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.CreateWebhook(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;
             }
@@ -41,8 +41,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.GetAsync(Router.RetrieveWebhook(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;
             }
@@ -53,8 +53,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PutAsync(Router.UpdateWebhook(id), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;
             }
@@ -64,8 +64,8 @@ namespace Facturapi.Wrappers
         {
             using (var response = await client.DeleteAsync(Router.DeleteWebhook(id), cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;
             }
@@ -76,8 +76,8 @@ namespace Facturapi.Wrappers
             using (var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json"))
             using (var response = await client.PostAsync(Router.ValidateSignature(), content, cancellationToken))
             {
-                await this.ThrowIfErrorAsync(response, cancellationToken);
-                var resultString = await response.Content.ReadAsStringAsync();
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var webhook = JsonConvert.DeserializeObject<Webhook>(resultString, this.jsonSettings);
                 return webhook;
             }

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -17,7 +17,7 @@
     <ApplicationIcon>facturapi.ico</ApplicationIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <Nullable>annotations</Nullable>
+    <Nullable>disable</Nullable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Facturapi</RootNamespace>
     <AssemblyName>Facturapi</AssemblyName>
     <PackageId>Facturapi</PackageId>
@@ -11,14 +11,19 @@
       API Keys creando una cuenta gratuita en https://www.facturapi.io</Summary>
     <PackageTags>factura factura-electronica cfdi facturapi mexico conekta</PackageTags>
     <Title>Facturapi</Title>
-    <Version>5.1.1</Version>
+    <Version>6.0.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Owners>Facturapi</Owners>
     <ApplicationIcon>facturapi.ico</ApplicationIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <LangVersion>latest</LangVersion>
+    <Nullable>annotations</Nullable>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Company>Facturación Espacial</Company>
     <Copyright>Facturación Espacial © 2025</Copyright>
-    <PackageProjectUrl>www.facturapi.io</PackageProjectUrl>
+    <PackageProjectUrl>https://www.facturapi.io</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/facturapi/facturapi-net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -29,11 +34,14 @@
     <Content Include="facturapi.ico" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  <ItemGroup>
+    <Compile Remove="FacturapiTest/**/*.cs" />
+    <None Include="FacturapiTest/**/*.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/facturapi-net.sln
+++ b/facturapi-net.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34322.80
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/facturapi-net.sln
+++ b/facturapi-net.sln
@@ -1,19 +1,46 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34322.80
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "facturapi-net", "facturapi-net.csproj", "{11E14BFA-6A9B-43D6-828F-B493E1617326}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FacturapiTest", "FacturapiTest\FacturapiTest.csproj", "{C424B990-E6E7-428C-9BA3-BD08BD5246A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Debug|x64.Build.0 = Debug|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Debug|x86.Build.0 = Debug|Any CPU
 		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Release|x64.ActiveCfg = Release|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Release|x64.Build.0 = Release|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Release|x86.ActiveCfg = Release|Any CPU
+		{11E14BFA-6A9B-43D6-828F-B493E1617326}.Release|x86.Build.0 = Release|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Debug|x64.Build.0 = Debug|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Debug|x86.Build.0 = Debug|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Release|x64.ActiveCfg = Release|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Release|x64.Build.0 = Release|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Release|x86.ActiveCfg = Release|Any CPU
+		{C424B990-E6E7-428C-9BA3-BD08BD5246A0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- switch `IFacturapiClient` to wrapper interfaces and update `FacturapiClient` accordingly
- drop `net452` and keep `netstandard2.0`, `net6.0`, and `net8.0`
- add advanced factory `FacturapiClient.CreateWithCustomHttpClient(...)` (without expanding the public constructor)
- harden wrappers (`Retention.CancelAsync`, `StampDraftAsync` + obsolete alias, null-safe query builder, `ConfigureAwait(false)` consistency)
- add `FacturapiTest` regression suite and run tests in CI before NuGet publish
- refresh README + CHANGELOG with migration-first guidance

## Commits
1. `feat!: modernize client contract and runtime targets`
2. `test(ci): add regression test project and run it before publish`
3. `docs: prioritize migration guidance and update usage examples`

## Validation
- `dotnet restore`
- `dotnet build facturapi-net.sln -c Release --no-restore`
- `dotnet test FacturapiTest/FacturapiTest.csproj -c Release --no-build`
