### PR TITLE
FAC-1936: add constants for tax, cancellation, and global invoice fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2026-04-01
+
+### Added
+
+- Added `TaxFactor` and `IepsMode` constants for tax payload fields.
+- Added `CancellationMotive` and `CancellationStatus` constants for cancellation flows.
+- Added `GlobalPeriodicity`, `GlobalMonths`, and `ExportCode` constants for global invoice payload fields.
+- Added `InvoiceStatus` and `ReceiptStatus` constants for common document status handling.
+- Added `receipt.cancellation_status_updated` to webhook event constants.
+
+### Changed
+
+- Updated `TaxSystem` constants to include missing SAT regime code `625`.
+- Expanded `Taxability` constants to include codes `06`, `07`, and `08`.
+
 ## [6.0.0] - 2026-03-30
 
 ### Migration Guide

--- a/Constants/CancellationMotive.cs
+++ b/Constants/CancellationMotive.cs
@@ -1,0 +1,10 @@
+namespace Facturapi
+{
+    public static class CancellationMotive
+    {
+        public const string COMPROBANTE_EMITIDO_CON_ERRORES_CON_RELACION = "01";
+        public const string COMPROBANTE_EMITIDO_CON_ERRORES_SIN_RELACION = "02";
+        public const string NO_SE_LLEVO_A_CABO_LA_OPERACION = "03";
+        public const string OPERACION_NOMINATIVA_RELACIONADA_EN_GLOBAL = "04";
+    }
+}

--- a/Constants/CancellationStatus.cs
+++ b/Constants/CancellationStatus.cs
@@ -1,0 +1,12 @@
+namespace Facturapi
+{
+    public static class CancellationStatus
+    {
+        public const string NONE = "none";
+        public const string VERIFYING = "verifying";
+        public const string PENDING = "pending";
+        public const string ACCEPTED = "accepted";
+        public const string REJECTED = "rejected";
+        public const string EXPIRED = "expired";
+    }
+}

--- a/Constants/ExportCode.cs
+++ b/Constants/ExportCode.cs
@@ -1,0 +1,10 @@
+namespace Facturapi
+{
+    public static class ExportCode
+    {
+        public const string NO_APLICA = "01";
+        public const string DEFINITIVA = "02";
+        public const string TEMPORAL = "03";
+        public const string DEFINITIVA_CON_CLAVE_DISTINTA_A_A1_O_NO_APLICA = "04";
+    }
+}

--- a/Constants/GlobalMonths.cs
+++ b/Constants/GlobalMonths.cs
@@ -1,0 +1,24 @@
+namespace Facturapi
+{
+    public static class GlobalMonths
+    {
+        public const string ENERO = "01";
+        public const string FEBRERO = "02";
+        public const string MARZO = "03";
+        public const string ABRIL = "04";
+        public const string MAYO = "05";
+        public const string JUNIO = "06";
+        public const string JULIO = "07";
+        public const string AGOSTO = "08";
+        public const string SEPTIEMBRE = "09";
+        public const string OCTUBRE = "10";
+        public const string NOVIEMBRE = "11";
+        public const string DICIEMBRE = "12";
+        public const string ENERO_FEBRERO = "13";
+        public const string MARZO_ABRIL = "14";
+        public const string MAYO_JUNIO = "15";
+        public const string JULIO_AGOSTO = "16";
+        public const string SEPTIEMBRE_OCTUBRE = "17";
+        public const string NOVIEMBRE_DICIEMBRE = "18";
+    }
+}

--- a/Constants/GlobalPeriodicity.cs
+++ b/Constants/GlobalPeriodicity.cs
@@ -1,0 +1,11 @@
+namespace Facturapi
+{
+    public static class GlobalPeriodicity
+    {
+        public const string DAY = "day";
+        public const string WEEK = "week";
+        public const string FORTNIGHT = "fortnight";
+        public const string MONTH = "month";
+        public const string TWO_MONTHS = "two_months";
+    }
+}

--- a/Constants/IepsMode.cs
+++ b/Constants/IepsMode.cs
@@ -1,0 +1,10 @@
+namespace Facturapi
+{
+    public static class IepsMode
+    {
+        public const string SUM_BEFORE_TAXES = "sum_before_taxes";
+        public const string BREAK_DOWN = "break_down";
+        public const string UNIT = "unit";
+        public const string SUBTRACT_BEFORE_BREAK_DOWN = "subtract_before_break_down";
+    }
+}

--- a/Constants/InvoiceStatus.cs
+++ b/Constants/InvoiceStatus.cs
@@ -1,0 +1,10 @@
+namespace Facturapi
+{
+    public static class InvoiceStatus
+    {
+        public const string PENDING = "pending";
+        public const string VALID = "valid";
+        public const string CANCELED = "canceled";
+        public const string DRAFT = "draft";
+    }
+}

--- a/Constants/ReceiptStatus.cs
+++ b/Constants/ReceiptStatus.cs
@@ -1,0 +1,10 @@
+namespace Facturapi
+{
+    public static class ReceiptStatus
+    {
+        public const string OPEN = "open";
+        public const string CANCELED = "canceled";
+        public const string INVOICED_TO_CUSTOMER = "invoiced_to_customer";
+        public const string INVOICED_GLOBALLY = "invoiced_globally";
+    }
+}

--- a/Constants/TaxFactor.cs
+++ b/Constants/TaxFactor.cs
@@ -1,0 +1,9 @@
+namespace Facturapi
+{
+    public static class TaxFactor
+    {
+        public const string TASA = "Tasa";
+        public const string CUOTA = "Cuota";
+        public const string EXENTO = "Exento";
+    }
+}

--- a/Constants/TaxSystem.cs
+++ b/Constants/TaxSystem.cs
@@ -12,23 +12,24 @@ namespace Facturapi
         public const string PERSONAS_MORALES_CON_FINES_NO_LUCRATIVOS = "603";
         public const string SUELDOS_Y_SALARIOS = "605";
         public const string ARRENDAMIENTO = "606";
+        public const string REGIMEN_DE_ENAJENACION_O_ADQUISICION_DE_BIENES = "607";
         public const string DEMAS_INGRESOS = "608";
         public const string CONSOLIDACION = "609";
         public const string RESIDENTES_EN_EL_EXTRANJERO = "610";
         public const string INGRESOS_POR_DIVIDENDOS_SOCIOS_Y_ACCIONISTAS = "611";
         public const string PERSONAS_FISICAS_CON_ACTIVIDADES_EMPRESARIALES_Y_PROFESIONALES = "612";
         public const string INGRESOS_POR_INTERESES = "614";
+        public const string REGIMEN_DE_LOS_INGRESOS_POR_OBTENCION_DE_PREMIOS = "615";
         public const string SIN_OBLIGACIONES_FISCALES = "616";
         public const string SOCIEDADES_COOPERATIVAS_DE_PRODUCCION = "620";
         public const string REGIMEN_DE_INCORPORACION_FISCAL = "621";
         public const string ACTIVIDADES_AGRICOLAS_GANADERAS_SILVICOLAS_Y_PESQUERAS = "622";
         public const string OPCIONAL_PARA_GRUPOS_DE_SOCIEDADES = "623";
         public const string COORDINADOS = "624";
+        public const string REGIMEN_DE_ACTIVIDADES_EMPRESARIALES_CON_INGRESOS_A_TRAVES_DE_PLATAFORMAS_TECNOLOGICAS = "625";
         public const string RESICO = "626";
         public const string HIDROCARBUROS = "628";
-        public const string REGIMEN_DE_ENAJENACION_O_ADQUISICION_DE_BIENES = "607";
         public const string PREFERENTES_Y_EMPRESAS_MULTINACIONALES = "629";
         public const string ENAJENACION_DE_ACCIONES_EN_BOLSA_DE_VALORES = "630";
-        public const string REGIMEN_DE_LOS_INGRESOS_POR_OBTENCION_DE_PREMIOS = "615";
     }
 }

--- a/Constants/Taxability.cs
+++ b/Constants/Taxability.cs
@@ -7,5 +7,8 @@ namespace Facturapi
         public const string SI_Y_NO_OBLIGADO_A_DESGLOSE = "03";
         public const string SI_Y_NO_CAUSA_IMPUESTO = "04";
         public const string PODEBI = "05";
+        public const string SI_IVA_PERO_SIN_IVA_TRASLADADO = "06";
+        public const string NO_IVA_PERO_DESGLOSE_IEPS_REQUERIDO = "07";
+        public const string NO_IVA_Y_NO_DESGLOSE_IEPS_REQUERIDO = "08";
     }
 }

--- a/Constants/WebhookEvents.cs
+++ b/Constants/WebhookEvents.cs
@@ -8,6 +8,7 @@ namespace Facturapi
         public const string INVOICES_CREATED_FROM_DASHBOARD = "invoice.created_from_dashboard";
         public const string RECEIPT_SELF_INVOICE_COMPLETE = "receipt.self_invoice_complete";
         public const string RECEIPT_STATUS_UPDATED = "receipt.status_updated";
+        public const string RECEIPT_CANCELLATION_STATUS_UPDATED = "receipt.cancellation_status_updated";
         public const string CUSTOMER_EDIT_LINK_COMPLETED = "customer.edit_link_completed";
     }
 }

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -7,22 +7,27 @@
     <PackageId>Facturapi</PackageId>
     <Authors>Javier Rosas</Authors>
     <PackageIcon>icon.png</PackageIcon>
-    <Summary>Genera facturas electrónicas válidas en México (CFDI) lo más fácil posible. Obtén tus
-      API Keys creando una cuenta gratuita en https://www.facturapi.io</Summary>
-    <PackageTags>factura factura-electronica cfdi facturapi mexico conekta</PackageTags>
+    <Description>SDK oficial de Facturapi para .NET. Integra facturación electrónica en México (CFDI) de forma simple y obtén una perspectiva fiscal completa de tu operación, con búsquedas indexadas, envío de documentos y trazabilidad.</Description>
+    <Summary>SDK oficial de Facturapi para .NET para facturación electrónica en México (CFDI), envío de documentos, búsqueda y trazabilidad.</Summary>
+    <PackageTags>factura factura-electronica facturacion cfdi cfdi40 sat invoice invoicing facturapi mexico</PackageTags>
     <Title>Facturapi</Title>
     <Version>6.1.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes>https://github.com/FacturAPI/facturapi-net/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <Owners>Facturapi</Owners>
     <ApplicationIcon>facturapi.ico</ApplicationIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Company>Facturación Espacial</Company>
-    <Copyright>Facturación Espacial © 2025</Copyright>
+    <Copyright>Facturación Espacial © 2026</Copyright>
     <PackageProjectUrl>https://www.facturapi.io</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/facturapi/facturapi-net</RepositoryUrl>

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -11,7 +11,7 @@
       API Keys creando una cuenta gratuita en https://www.facturapi.io</Summary>
     <PackageTags>factura factura-electronica cfdi facturapi mexico conekta</PackageTags>
     <Title>Facturapi</Title>
-    <Version>6.0.0</Version>
+    <Version>6.1.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Owners>Facturapi</Owners>
     <ApplicationIcon>facturapi.ico</ApplicationIcon>


### PR DESCRIPTION
## Summary
- add constants for tax fields (`TaxFactor`, `IepsMode`)
- add constants for cancellation (`CancellationMotive`, `CancellationStatus`)
- add constants for global invoice fields (`GlobalPeriodicity`, `GlobalMonths`, `ExportCode`)
- add status constants for common document flows (`InvoiceStatus`, `ReceiptStatus`)
- update `TaxSystem` with missing SAT codes and expand `Taxability` values
- add missing webhook event constant `receipt.cancellation_status_updated`

## Validation
- `dotnet build -nologo`
