### PR TITLE
feat(invoices): agregar métodos ZIP y cuentas prediales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [6.7.0] - 2026-08-21
 ### Added
 - Added invoice ZIP request methods: `CreateZipRequestAsync`, `ListZipRequestsAsync`, `RetrieveZipRequestAsync`, and `DownloadZipRequestAsync`.
 
+### Fixed
+- Expose `InvoiceItem.PropertyTaxAccount` as a list of property tax account numbers.
 ## [6.6.0] - 2026-07-01
 ### Added
 - Added retention draft methods: `UpdateDraftAsync`, `StampDraftAsync`, and `CopyToDraftAsync`.

--- a/FacturapiTest/ClientCompatibilityTests.cs
+++ b/FacturapiTest/ClientCompatibilityTests.cs
@@ -53,6 +53,32 @@ namespace FacturapiTest
         }
 
         [Fact]
+        public async Task InvoiceRetrieveAsync_DeserializesPropertyTaxAccounts()
+        {
+            var handler = new StubHttpMessageHandler((request, cancellationToken) =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"id\":\"inv_123\",\"items\":[{\"property_tax_account\":[\"0102030405\"]}]}",
+                        Encoding.UTF8,
+                        "application/json")
+                };
+                return Task.FromResult(response);
+            });
+
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://www.facturapi.io/v2/")
+            };
+            var wrapper = new InvoiceWrapper("test_key", "v2", httpClient);
+
+            var invoice = await wrapper.RetrieveAsync("inv_123");
+
+            Assert.Equal(new[] { "0102030405" }, invoice.Items[0].PropertyTaxAccount);
+        }
+
+        [Fact]
         public async Task InvoiceStampDraftAsync_AndLegacyMethod_BothWork()
         {
             var handler = new StubHttpMessageHandler((request, cancellationToken) =>

--- a/Models/InvoiceItem.cs
+++ b/Models/InvoiceItem.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using System.Collections.Generic;
+
 namespace Facturapi
 {
     public class InvoiceItem
@@ -8,5 +10,6 @@ namespace Facturapi
         public Decimal Discount { get; set; }
         public string Description { get; set; }
         public Product Product { get; set; }
+        public List<string> PropertyTaxAccount { get; set; }
     }
 }

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -11,7 +11,7 @@
     <Summary>SDK oficial de Facturapi para .NET para facturación electrónica en México (CFDI), envío de documentos, búsqueda y trazabilidad.</Summary>
     <PackageTags>factura factura-electronica facturacion cfdi cfdi40 sat invoice invoicing facturapi mexico</PackageTags>
     <Title>Facturapi</Title>
-    <Version>6.6.0</Version>
+    <Version>6.7.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
## Objetivo

Publicar la siguiente versión del SDK con los métodos para solicitar archivos ZIP y el tipo correcto para cuentas prediales.

## Cambios

- Agrega métodos para solicitar ZIP de facturas y retenciones.
- Conserva el contrato de `IFacturapiClient` e interfaces de wrappers para mocks e inyección.
- Modela `PropertyTaxAccount` como lista, conforme al CFDI.
- Publica la versión `6.7.0`.

## Verificación

- Pruebas en `net8.0` y `net6.0`.