### PR TITLE
feat: add GetPaymentSummaryAsync for payment complements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.7.0] - 2026-08-21
+## [6.8.0] - 2026-09-04
+### Added
+- Added `GetPaymentSummaryAsync` to get the related-document object needed to build a payment complement (complemento de pago): installment number, previous balance, and taxes prorated to the paid amount.
+
+## [6.7.0] - 2026-08-24
 ### Added
 - Added invoice ZIP request methods: `CreateZipRequestAsync`, `ListZipRequestsAsync`, `RetrieveZipRequestAsync`, and `DownloadZipRequestAsync`.
 
 ### Fixed
 - Expose `InvoiceItem.PropertyTaxAccount` as a list of property tax account numbers.
+
 ## [6.6.0] - 2026-07-01
 ### Added
 - Added retention draft methods: `UpdateDraftAsync`, `StampDraftAsync`, and `CopyToDraftAsync`.

--- a/FacturapiTest/WrapperBehaviorTests.cs
+++ b/FacturapiTest/WrapperBehaviorTests.cs
@@ -38,6 +38,26 @@ namespace FacturapiTest
         }
 
         [Fact]
+        public async Task InvoiceGetPaymentSummaryAsync_UsesPaymentSummaryRoute()
+        {
+            var handler = new RecordingHandler((request, cancellationToken) =>
+            {
+                Assert.Equal(HttpMethod.Get, request.Method);
+                Assert.NotNull(request.RequestUri);
+                Assert.Equal("/v2/invoices/inv_123/payment-summary?amount=58", request.RequestUri.PathAndQuery);
+                return Task.FromResult(JsonResponse("{\"uuid\":\"6CF6CE33-1BD2-4F88-A443-33013C069169\",\"installment\":1,\"last_balance\":100,\"total\":100,\"currency\":\"MXN\",\"amount\":58,\"taxes\":[{\"base\":50,\"rate\":0.16,\"type\":\"IVA\",\"factor\":\"Tasa\",\"withholding\":false}]}"));
+            });
+
+            var wrapper = new InvoiceWrapper("test_key", "v2", CreateHttpClient(handler));
+            var result = await wrapper.GetPaymentSummaryAsync("inv_123", 58);
+
+            Assert.Equal("6CF6CE33-1BD2-4F88-A443-33013C069169", result.Uuid);
+            Assert.Equal(1, result.Installment);
+            Assert.Equal(50m, result.Taxes[0].Base);
+            Assert.False(result.Taxes[0].Withholding);
+        }
+
+        [Fact]
         public async Task ReceiptCancelAsync_UsesReceiptDeleteRoute()
         {
             var handler = new RecordingHandler((request, cancellationToken) =>

--- a/Models/PaymentSummary.cs
+++ b/Models/PaymentSummary.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Facturapi
+{
+    public class PaymentSummary
+    {
+        public string Uuid { get; set; }
+        public decimal? FolioNumber { get; set; }
+        public string Series { get; set; }
+        public int Installment { get; set; }
+        public decimal LastBalance { get; set; }
+        public decimal Total { get; set; }
+        public string Currency { get; set; }
+        public decimal Amount { get; set; }
+        public List<PaymentSummaryTax> Taxes { get; set; }
+    }
+
+    public class PaymentSummaryTax
+    {
+        public decimal Base { get; set; }
+        public decimal Rate { get; set; }
+        public string Type { get; set; }
+        public string Factor { get; set; }
+        public bool Withholding { get; set; }
+    }
+}

--- a/Router/InvoiceRouter.cs
+++ b/Router/InvoiceRouter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,6 +16,14 @@ namespace Facturapi
         public static string RetrieveInvoice(string id)
         {
             return $"invoices/{id}";
+        }
+
+        public static string RetrieveInvoicePaymentSummary(string id, double amount)
+        {
+            return UriWithQuery($"{RetrieveInvoice(id)}/payment-summary", new Dictionary<string, object>
+            {
+                ["amount"] = amount
+            });
         }
 
         public static string CreateInvoice(Dictionary<string, object> query = null)

--- a/Wrappers/IInvoiceWrapper.cs
+++ b/Wrappers/IInvoiceWrapper.cs
@@ -11,6 +11,7 @@ namespace Facturapi.Wrappers
         Task<SearchResult<Invoice>> ListAsync(Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
         Task<Invoice> CreateAsync(Dictionary<string, object> data, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
         Task<Invoice> RetrieveAsync(string id, CancellationToken cancellationToken = default);
+        Task<PaymentSummary> GetPaymentSummaryAsync(string id, double amount, CancellationToken cancellationToken = default);
         Task<Invoice> CancelAsync(string id, Dictionary<string, object> query = null, CancellationToken cancellationToken = default);
         Task SendByEmailAsync(string id, Dictionary<string, object> data = null, CancellationToken cancellationToken = default);
         Task<Stream> DownloadZipAsync(string id, CancellationToken cancellationToken = default);

--- a/Wrappers/InvoiceWrapper.cs
+++ b/Wrappers/InvoiceWrapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
@@ -47,6 +47,17 @@ namespace Facturapi.Wrappers
                 var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var invoice = JsonConvert.DeserializeObject<Invoice>(resultString, this.jsonSettings);
                 return invoice;
+            }
+        }
+
+        public async Task<PaymentSummary> GetPaymentSummaryAsync(string id, double amount, CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(Router.RetrieveInvoicePaymentSummary(id, amount), cancellationToken).ConfigureAwait(false))
+            {
+                await this.ThrowIfErrorAsync(response, cancellationToken).ConfigureAwait(false);
+                var resultString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var summary = JsonConvert.DeserializeObject<PaymentSummary>(resultString, this.jsonSettings);
+                return summary;
             }
         }
 

--- a/facturapi-net.csproj
+++ b/facturapi-net.csproj
@@ -11,7 +11,7 @@
     <Summary>SDK oficial de Facturapi para .NET para facturación electrónica en México (CFDI), envío de documentos, búsqueda y trazabilidad.</Summary>
     <PackageTags>factura factura-electronica facturacion cfdi cfdi40 sat invoice invoicing facturapi mexico</PackageTags>
     <Title>Facturapi</Title>
-    <Version>6.7.0</Version>
+    <Version>6.8.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Adds `InvoiceWrapper.GetPaymentSummaryAsync(id, amount)` (and `IInvoiceWrapper` member), calling `GET /invoices/{id}/payment-summary?amount=` and deserializing into the new `PaymentSummary`/`PaymentSummaryTax` models.

The response is the related-document object needed to build a payment complement (complemento de pago): installment number from the payment history, previous balance, and taxes prorated to the paid amount.

- Version bump 6.7.0 → 6.8.0 with changelog entry (also fixes the 6.7.0 release date).
- Stacks on `fix/property-tax-accounts`.
- Tests: full suite passing (34 tests).