### PR TITLE
Document selecting API error language

### DIFF
--- a/FacturapiTest/ClientCompatibilityTests.cs
+++ b/FacturapiTest/ClientCompatibilityTests.cs
@@ -110,6 +110,7 @@ namespace FacturapiTest
         {
             var handler = new StubHttpMessageHandler((request, cancellationToken) =>
             {
+                Assert.Equal("en-US", Assert.Single(request.Headers.AcceptLanguage).Value);
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("{\"ok\":true}", Encoding.UTF8, "application/json")
@@ -122,6 +123,7 @@ namespace FacturapiTest
                 BaseAddress = new Uri("https://www.facturapi.io/v2/")
             };
 
+            injectedHttpClient.DefaultRequestHeaders.AcceptLanguage.ParseAdd("en-US");
             var client = FacturapiClient.CreateWithCustomHttpClient("test_key", injectedHttpClient, "v2");
 
             var healthy = await client.Tool.HealthCheckAsync();

--- a/README.md
+++ b/README.md
@@ -183,6 +183,22 @@ await zipStream.CopyToAsync(file);
 await facturapi.Invoice.SendByEmailAsync(invoice.Id);
 ```
 
+## Idioma de los errores de la API
+
+En API V2 puedes solicitar mensajes de error en inglés con `Accept-Language`. Usa la configuración existente del cliente:
+
+```csharp
+using Facturapi;
+using System.Net.Http;
+
+using var httpClient = new HttpClient();
+httpClient.DefaultRequestHeaders.AcceptLanguage.ParseAdd("en");
+using var facturapi = FacturapiClient.CreateWithCustomHttpClient(
+    "YOUR_API_KEY", httpClient);
+```
+
+Usa `es` para español. También se aceptan variantes como `en-US` y preferencias como `en;q=0.9, es;q=0.5`. Sin el header o sin un idioma compatible, la API usa español. La preferencia se aplica a todas las solicitudes de esta instancia; usa instancias separadas si necesitas varios idiomas. Los códigos no cambian y los mensajes externos SAT/PAC y los mensajes legacy no catalogados conservan su idioma original. La localización depende del soporte de API V2 en el servidor; no traduce errores locales del SDK.
+
 ## Documentación
 
 Hay muchas más cosas que puedes hacer con esta librería: listar, consultar, actualizar y eliminar clientes, productos y facturas.


### PR DESCRIPTION
Documents how to request English API V2 errors with `HttpClient.DefaultRequestHeaders.AcceptLanguage` and the existing custom-client factory. The example explains client lifetime, fallback behavior, stable codes, external messages, local SDK errors, and instance-level configuration.

The existing injected-client test now verifies that `Accept-Language: en-US` reaches the request.


Validation: .NET 6 test suite passed with 34 tests. Existing XML documentation warnings remain unchanged.

